### PR TITLE
Explicitly set OTLP protocol in all non-Go examples

### DIFF
--- a/apps/game-of-life/go/docker-compose-otel.yaml
+++ b/apps/game-of-life/go/docker-compose-otel.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=game-of-life-webapp-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - HTTP_PORT=8080
       - SERVER_ADDRESS=game-of-life-server:8081
@@ -25,6 +26,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=game-of-life-server-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - GRPC_PORT=8081
       - HTTP_PORT=8082

--- a/apps/kafka-redis-messages/otel-api-with-dd/docker-compose-otel.yaml
+++ b/apps/kafka-redis-messages/otel-api-with-dd/docker-compose-otel.yaml
@@ -82,6 +82,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-consumer-go-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent-kafka-otel:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=otelapi-with-dd-kafka,host.name=otelcol-docker
       - REDIS_HOST=redis-otel
       - KAFKA_SERVERS=kafka-otel:9092

--- a/apps/kafka-redis-messages/otel/docker-compose-otel.yaml
+++ b/apps/kafka-redis-messages/otel/docker-compose-otel.yaml
@@ -53,6 +53,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-producer-java-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent-kafka-otel:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=otel-kafka,host.name=otelcol-docker
       - SERVER_PORT=9090
       - KAFKA_SERVERS=kafka-otel:9092
@@ -73,6 +74,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-consumer-go-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent-kafka-otel:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=otel-kafka,host.name=otelcol-docker
       - REDIS_HOST=redis-otel
       - KAFKA_SERVERS=kafka-otel:9092

--- a/apps/manual-container-metrics/values.yaml
+++ b/apps/manual-container-metrics/values.yaml
@@ -93,6 +93,8 @@ spec:
               value: "4317"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: 'http://$(HOST_IP):$(OTLP_GRPC_PORT)'
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: grpc
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: >-
                 service.name=$(OTEL_SERVICE_NAME),

--- a/apps/rest-services/dotnet/docker-compose-dd-otel.yaml
+++ b/apps/rest-services/dotnet/docker-compose-dd-otel.yaml
@@ -26,6 +26,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=random-date-dotnet-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - ASPNETCORE_URLS=http://+:5078
     ports:

--- a/apps/rest-services/dotnet/docker-compose-otel.yaml
+++ b/apps/rest-services/dotnet/docker-compose-otel.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=random-date-dotnet-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - ASPNETCORE_URLS=http://+:5078
     ports:

--- a/apps/rest-services/java/calendar/deploys/calendar-dd/templates/deployment.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar-dd/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               value: "4317"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: 'http://$(HOST_IP):$(OTLP_GRPC_PORT)'
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: 'grpc'
             - name: DD_VERSION
               value: "1.0-beta"
             - name: DD_TRACE_OTEL_ENABLED

--- a/apps/rest-services/java/calendar/deploys/docker/docker-compose-otel-agent.yaml
+++ b/apps/rest-services/java/calendar/deploys/docker/docker-compose-otel-agent.yaml
@@ -15,6 +15,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-otel-agent
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_LOGS_EXPORTER=otlp
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc

--- a/apps/rest-services/java/calendar/run-otel-local.sh
+++ b/apps/rest-services/java/calendar/run-otel-local.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-# export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 # Define the path to the Java agent JAR
 JAVA_AGENT_JAR="$SCRIPT_DIR/opentelemetry-javaagent.jar"

--- a/apps/rolldice-game/docker-compose.yml
+++ b/apps/rolldice-game/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=controller
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 
   rolling:
@@ -30,6 +31,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=rolly
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 
   scoring:
@@ -44,7 +46,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=scorey
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
-
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
   otelcol:
     image: otel/opentelemetry-collector-contrib

--- a/apps/span-links/otel/docker-compose-otel.yaml
+++ b/apps/span-links/otel/docker-compose-otel.yaml
@@ -39,6 +39,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=words-producer-java-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent-kafka-otel:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=otel-kafka,host.name=otelcol-docker
       - SERVER_PORT=9090
       - KAFKA_SERVERS=kafka-otel:9092

--- a/apps/w3c-trace-context/docker-compose-dd-java-otel-py.yaml
+++ b/apps/w3c-trace-context/docker-compose-dd-java-otel-py.yaml
@@ -27,6 +27,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-py-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - OTEL_TRACES_EXPORTER=otlp
       - OTEL_METRICS_EXPORTER=otlp

--- a/apps/w3c-trace-context/docker-compose-dd-otel-both.yaml
+++ b/apps/w3c-trace-context/docker-compose-dd-otel-both.yaml
@@ -30,6 +30,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-java-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - CALENDAR_SERVICE_URL=http://calendar-py-dd:9090
       - SERVER_PORT=8081
@@ -63,6 +64,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-py-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - OTEL_TRACES_EXPORTER=otlp
       - OTEL_METRICS_EXPORTER=otlp

--- a/apps/w3c-trace-context/docker-compose-otel-java-dd-py.yaml
+++ b/apps/w3c-trace-context/docker-compose-otel-java-dd-py.yaml
@@ -11,6 +11,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=calendar-java-otel
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
       - CALENDAR_SERVICE_URL=http://calendar-py-dd:9090
       - SERVER_PORT=8080


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Explicitly set OTLP protocol variant in all examples that do not use Golang.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The default protocol variant used is SDK-dependent (see https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol),
so it may change across major versions of the OTel SDK dependencies. We explicitly set this to avoid breaking examples if this changes ([it did in Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md#version-200-2024-01-12))!

In Golang, we explicitly use gRPC exporter, so the environment variable would be a bit confusing.
