### PR TITLE
Fix missing package json when spinning up the game_controller

### DIFF
--- a/apps/rolldice-game/game_controller/Dockerfile
+++ b/apps/rolldice-game/game_controller/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /game_controller
 COPY . ./game_controller
 COPY package*.json ./game_controller/
 
-WORKDIR /game_controller
+WORKDIR /game_controller/game_controller
 
 # Install the project dependencies
 RUN npm install
@@ -20,4 +20,4 @@ ENV logs_exporter=otlp
 EXPOSE 5002
 
 # Define the command to run the app
-CMD [ "node", "game_controller/controller.js" ]
+CMD [ "node", "controller.js" ]


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When I try to spin up the app in `apps/rolldice-game/`, the `game_controller` container fails to spin up with this error:

```
Error: Cannot find module 'express'
Require stack:
- /game_controller/game_controller/controller.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:931:15)
    at Function.Module._load (internal/modules/cjs/loader.js:774:27)
    at Module.require (internal/modules/cjs/loader.js:1003:19)
    at require (internal/modules/cjs/helpers.js:107:18)
    at Object.<anonymous> (/game_controller/game_controller/controller.js:1:17)
    at Module._compile (internal/modules/cjs/loader.js:1114:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1143:10)
    at Module.load (internal/modules/cjs/loader.js:979:32)
    at Function.Module._load (internal/modules/cjs/loader.js:819:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/game_controller/game_controller/controller.js' ]
}
```

This has to do with how the Dockerfile currently copies files over.

The folder with the package.json is `/game_controller/game_controller` , not `/game_controller`.
 