### PR TITLE
OTEL-2058 Update Calendar App image to use the latest multi-platform tag

### DIFF
--- a/apps/rest-services/java/calendar/deploys/calendar/templates/deployment.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar/templates/deployment.yaml
@@ -91,3 +91,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/rest-services/java/calendar/deploys/calendar/values.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: datadog/opentelemetry-examples
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "calendar-java-20240815-01"
+  tag: "calendar-java-20240826"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/apps/rest-services/java/calendar/deploys/calendar/values.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 image:
   repository: datadog/opentelemetry-examples
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "calendar-java-20240826"
 imagePullSecrets: []

--- a/apps/rest-services/java/calendar/deploys/calendar/values.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar/values.yaml
@@ -45,3 +45,4 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 tolerations: []
 affinity: {}
+nodeSelector: {}


### PR DESCRIPTION
### What does this PR do?

* Use the latest `datadog/opentelemetry-examples:calendar-java-20240826` multi-platform image tag
* Switch to `imagePullPolicy: Always` to prevent cache invalidation issues
* Introduce `nodeSelector`: although we can utilize existing `affinity`/`tolerations`, the `nodeSelector` is the simplest recommended form of node selection constraint. It's extremely useful when we want to specify which nodes a pod should be scheduled on based on node labels, but do not need the fine-grained control provided by node affinity.

### Motivation

* Fixing the issues surfaced during bug bash
