### PR TITLE
update pull policy for Java calendar app

### DIFF
--- a/apps/rest-services/java/calendar/deploys/calendar/values.yaml
+++ b/apps/rest-services/java/calendar/deploys/calendar/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 image:
   repository: datadog/opentelemetry-examples
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "calendar-java-20240826"
 imagePullSecrets: []


### PR DESCRIPTION
We are now using a fixed calendar tag. No need to pull the image always. 