### PR TITLE
Remove default service from calendar-go

### DIFF
--- a/apps/manual-container-metrics/app/main.go
+++ b/apps/manual-container-metrics/app/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	ctx := context.Background()
 	// Create resource.
-	res, err := resource.New(ctx, resource.WithFromEnv())
+	res, err := resource.New(ctx, resource.WithFromEnv(), resource.WithContainer())
 	if err != nil {
 		log.Fatalf("failed to create resource: ", err)
 	}
@@ -93,7 +93,7 @@ func main() {
 	containerNetSent, err := meter.Float64UpDownCounter("container.net.sent")
 	containerNetRcvd, err := meter.Float64UpDownCounter("container.net.rcvd")
 
-	attr := metric2.WithAttributes(attribute.String("container.name", os.Getenv("OTEL_CONTAINER_NAME")), attribute.String("container.id", os.Getenv("OTEL_K8S_CONTAINER_ID")))
+	attr := metric2.WithAttributes(attribute.String("customer.attribute", "value"))
 	containerCpuUsage.Add(ctx, 1, attr)
 	containerCpuLimit.Add(ctx, 1, attr)
 	containerCpuUser.Add(ctx, 1, attr)

--- a/apps/manual-container-metrics/app/main.go
+++ b/apps/manual-container-metrics/app/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	ctx := context.Background()
 	// Create resource.
-	res, err := resource.New(ctx, resource.WithFromEnv(), resource.WithContainer())
+	res, err := resource.New(ctx, resource.WithFromEnv())
 	if err != nil {
 		log.Fatalf("failed to create resource: ", err)
 	}
@@ -93,7 +93,7 @@ func main() {
 	containerNetSent, err := meter.Float64UpDownCounter("container.net.sent")
 	containerNetRcvd, err := meter.Float64UpDownCounter("container.net.rcvd")
 
-	attr := metric2.WithAttributes(attribute.String("customer.attribute", "value"))
+	attr := metric2.WithAttributes(attribute.String("container.name", os.Getenv("OTEL_CONTAINER_NAME")), attribute.String("container.id", os.Getenv("OTEL_K8S_CONTAINER_ID")))
 	containerCpuUsage.Add(ctx, 1, attr)
 	containerCpuLimit.Add(ctx, 1, attr)
 	containerCpuUser.Add(ctx, 1, attr)

--- a/apps/rest-services/golang/calendar/k8s/deployment.yaml
+++ b/apps/rest-services/golang/calendar/k8s/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: calendar-rest-go
-          image: datadog/opentelemetry-examples:calendar-go-rest-0.15
+          image: datadog/opentelemetry-examples:calendar-go-rest-0.16
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/apps/rest-services/golang/calendar/main.go
+++ b/apps/rest-services/golang/calendar/main.go
@@ -22,13 +22,11 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.uber.org/zap"
 )
 
 const (
 	defaultPort = "9090"
-	serviceName = "OTEL_SERVICE_NAME"
 	PORT_STR    = "PORT"
 )
 
@@ -145,17 +143,13 @@ func realMain() error {
 	ctx := context.Background()
 
 	endpoint := fmt.Sprintf(":%s", getEnv(PORT_STR, defaultPort))
-	service := getEnv(serviceName, "calendar-otel")
 	var err error
-	logger, err = zap.NewDevelopment(zap.Fields(zap.String("service", service)))
+	logger, err = zap.NewDevelopment()
 	if err != nil {
 		return err
 	}
 	// resource.WithContainer() adds container.id which the agent will leverage to fetch container tags via the tagger.
-	res, err := resource.New(ctx, resource.WithContainer(),
-		resource.WithAttributes(semconv.ServiceName(service)),
-		resource.WithFromEnv(),
-	)
+	res, err := resource.New(ctx, resource.WithContainer(), resource.WithFromEnv())
 	if err != nil {
 		logger.Fatal("can't create resource", zap.Error(err))
 		return err

--- a/apps/rest-services/golang/calendar/main.go
+++ b/apps/rest-services/golang/calendar/main.go
@@ -28,6 +28,7 @@ import (
 const (
 	defaultPort = "9090"
 	PORT_STR    = "PORT"
+	name        = "calendar-rest-go"
 )
 
 var logger *zap.Logger
@@ -166,7 +167,7 @@ func realMain() error {
 			logger.Error("loggerProvider Shutdown failed", zap.Error(err))
 		}
 	}()
-	logger = zap.New(otelzap.NewCore(service, otelzap.WithLoggerProvider(loggerProvider)), zap.Fields(zap.String("service", service)))
+	logger = zap.New(otelzap.NewCore(name, otelzap.WithLoggerProvider(loggerProvider)))
 
 	tp, err := initTracerProvider(ctx, res)
 	if err != nil {
@@ -189,7 +190,7 @@ func realMain() error {
 			logger.Error("meterProvider Shutdown failed", zap.Error(err))
 		}
 	}()
-	server, err := NewServer(service, meterProvider)
+	server, err := NewServer(name, meterProvider)
 	if err != nil {
 		logger.Fatal("can't create new server", zap.Error(err))
 		return err


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Removes setting the default service on the calendar-go app.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We only want to set service and other resource attributes through environment variables for more flexibility in e2e tests. This way we can test setting either the OTel env vars or the Datadog env vars (i.e. `DD_ENV`) without conflicts.
