### PR TITLE
Add log trace correlation to calendar-rest-go

### DIFF
--- a/apps/rest-services/golang/calendar/go.mod
+++ b/apps/rest-services/golang/calendar/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.30.0
 	go.opentelemetry.io/otel/sdk/log v0.6.0
 	go.opentelemetry.io/otel/sdk/metric v1.30.0
+	go.opentelemetry.io/otel/trace v1.30.0
 	go.uber.org/zap v1.27.0
 )
 
@@ -28,7 +29,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect
 	go.opentelemetry.io/otel/log v0.6.0 // indirect
-	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/apps/rest-services/golang/calendar/k8s/deployment.yaml
+++ b/apps/rest-services/golang/calendar/k8s/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: calendar-rest-go
-          image: datadog/opentelemetry-examples:calendar-go-rest-0.16
+          image: datadog/opentelemetry-examples:calendar-go-rest-0.17
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/apps/rest-services/golang/calendar/server.go
+++ b/apps/rest-services/golang/calendar/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -86,13 +87,19 @@ func NewServer(name string, mp metric.MeterProvider) (*Server, error) {
 	}, nil
 }
 
-func getDate(_ context.Context) string {
+func getDate(ctx context.Context) string {
 	dayOffset := rand.Intn(365)
 	startDate := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.Local)
 	day := startDate.AddDate(0, 0, dayOffset)
 
 	d := day.Format(time.DateOnly)
-	logger.Info("random date", zap.String("date", d))
+	span := trace.SpanFromContext(ctx)
+	logger.Info(
+		"random date",
+		zap.String("date", d),
+		zap.String("dd.trace_id", span.SpanContext().TraceID().String()),
+		zap.String("dd.span_id", span.SpanContext().SpanID().String()),
+	)
 	return d
 }
 


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds log trace correlation to calendar-rest-go.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Needed for testing load balancing exporter functionality in e2e tests.