### PR TITLE
Add more telemetry for calendar-rest-go

### DIFF
--- a/apps/rest-services/golang/calendar/main.go
+++ b/apps/rest-services/golang/calendar/main.go
@@ -190,7 +190,7 @@ func realMain() error {
 			logger.Error("meterProvider Shutdown failed", zap.Error(err))
 		}
 	}()
-	server, err := NewServer(name, meterProvider)
+	server, err := NewServer(name, meterProvider, tp)
 	if err != nil {
 		logger.Fatal("can't create new server", zap.Error(err))
 		return err

--- a/apps/rest-services/golang/calendar/server.go
+++ b/apps/rest-services/golang/calendar/server.go
@@ -88,12 +88,17 @@ func NewServer(name string, mp metric.MeterProvider) (*Server, error) {
 }
 
 func getDate(ctx context.Context) string {
+	span := trace.SpanFromContext(ctx)
+	logger.Info(
+		"getting random date",
+		zap.String("dd.trace_id", span.SpanContext().TraceID().String()),
+		zap.String("dd.span_id", span.SpanContext().SpanID().String()),
+	)
 	dayOffset := rand.Intn(365)
 	startDate := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.Local)
 	day := startDate.AddDate(0, 0, dayOffset)
 
 	d := day.Format(time.DateOnly)
-	span := trace.SpanFromContext(ctx)
 	logger.Info(
 		"random date",
 		zap.String("date", d),


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a second log for getDate in calendar-rest-go. Also adds a nested client span in getDate.

### Motivation
The load balancing exporter e2e tests need at least two logs to verify multiple logs with the same trace id are sent to the same backend. The span receiver e2e tests also need a client span to verify operation/resource names.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
