### PR TITLE
Add context for log-trace correlation in calendar-rest-go

### DIFF
--- a/apps/rest-services/golang/calendar/k8s/deployment.yaml
+++ b/apps/rest-services/golang/calendar/k8s/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: calendar-rest-go
-          image: datadog/opentelemetry-examples:calendar-go-rest-0.17
+          image: datadog/opentelemetry-examples:calendar-go-rest-0.18
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/apps/rest-services/golang/calendar/server.go
+++ b/apps/rest-services/golang/calendar/server.go
@@ -103,6 +103,7 @@ func (s *Server) getDate(ctx context.Context) string {
 		"getting random date",
 		zap.String("dd.trace_id", span.SpanContext().TraceID().String()),
 		zap.String("dd.span_id", span.SpanContext().SpanID().String()),
+		zap.Any("context", ctx),
 	)
 	dayOffset := rand.Intn(365)
 	startDate := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.Local)
@@ -114,6 +115,7 @@ func (s *Server) getDate(ctx context.Context) string {
 		zap.String("date", d),
 		zap.String("dd.trace_id", span.SpanContext().TraceID().String()),
 		zap.String("dd.span_id", span.SpanContext().SpanID().String()),
+		zap.Any("context", ctx),
 	)
 	return d
 }


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Logs from calendar-rest-go are missing otel TraceID and SpanID. This PR adds the context field to the logs to automatically correlate traces with logs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
