### PR TITLE
Update kubernetes cluster collector config

### DIFF
--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -15,8 +15,6 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secret
         key: api-key
-  - name: CLUSTER_NAME
-    valueFrom: 
 
 config:
   receivers:
@@ -130,6 +128,12 @@ config:
           - from: resource_attribute
             name: k8s.pod.uid
     
+    transform/sum_to_gauge:
+      metric_statements:
+        - convert_sum_to_gauge() where metric.name == "k8s.service.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.node.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.job.count"
+
   connectors:
     # The count connector helps us generate three custom metrics by counting the number 
     # of metric series. It generates the following metrics:
@@ -156,7 +160,7 @@ config:
 
         k8s.job.count:
           conditions:
-            - metric.name == "kube_job_status_active"
+            - metric.name == "kube_job_owner"
 
   exporters:
     datadog/exporter:
@@ -171,5 +175,5 @@ config:
         
       metrics:
         receivers: [otlp, prometheus, count]
-        processors: [resource, transform/ksm_to_dd, transform/rename_uid, groupbyattrs, k8sattributes, cumulativetodelta]
+        processors: [resource, transform/ksm_to_dd, transform/rename_uid, groupbyattrs, k8sattributes, cumulativetodelta, transform/sum_to_gauge]
         exporters: [datadog/exporter]


### PR DESCRIPTION
### What does this PR do?
* Fixes an environment variable typo
* Changes the metric used to count jobs to better align with the Datadog [agent](https://github.com/DataDog/datadog-agent/blob/7c447e05dc5e2e3b1ef4c1293c539b3a6e2caa7f/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go#L346-L350)
* Transforms the count metrics from sums to gauges. This is to prevent them from being ingested as a `COUNT`. The goal of these metrics are to be direct equivalences to `kubernetes_state.job.count`, `kubernetes_state.node.count`, and `kubernetes_state.service.count` which are all `GAUGE`. 

#### Details about the override from `COUNT` to `GAUGE`
The Datadog Agent generates  `job`, `node`, and `service` `.count` using the [countObjectAggregator](https://github.com/DataDog/datadog-agent/blob/b539e28929d8320b69dbe0f02d3feb1d8f6f59fd/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go#L161-L173). Each KSM check execution the total number of unique tag combinations for `jobs`, `nodes`, and `services` (and more) are "accumulated" and correspond to the quantity of each resource present on the cluster, represented as a `GAUGE`. 

For example:
```
# TYPE kube_job_owner gauge
kube_job_owner{namespace="default",job_name="job-A",owner_kind="",owner_name="",owner_is_controller=""} 1
kube_job_owner{namespace="default",job_name="job-B",owner_kind="",owner_name="",owner_is_controller=""} 1
```
The above prometheus metrics would result in a `kubernetes_state.job.count` metric value of `2`.

Similarly in the OTel collector, we are using the [count connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector) to count the number of datapoints associated with a metric. By using the `cumulativetodelta` processor to set the [sum aggregation](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums) to `delta` we ensure that datapoint count resets each collection interval to match Datadog's KSM check.

For example:
```
 Descriptor:
      -> Name: kube_job_owner
      -> Description: [STABLE] Information about the Job's owner.
      -> Unit:
      -> DataType: Gauge
 NumberDataPoints #0
 Data point attributes:
      -> kube_job: Str(job-A)
      -> kube_namespace: Str(default)
 StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2025-08-06 18:21:34.312 +0000 UTC
 Value: 1.000000
 NumberDataPoints #1
 Data point attributes:
      -> kube_job: Str(job-B)
      -> kube_namespace: Str(default)
 StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2025-08-06 18:21:34.312 +0000 UTC
 Value: 1.000000
 ```
The above metric has 2 datapoints associated with it, so the resulting `k8s.job.count` metric has a value of `2`. Datadog interprets `count connector` metrics as `COUNT`, so it is required that we override the metric type to achieve parity with the Datadog metric equivalent. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
