### PR TITLE
Update docs to include pod memory usage and container id

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -55,6 +55,12 @@ Metric Type: Gauge
 Unit: core
 ```
 
+### k8s.pod.memory.usage
+```
+Metric Type: Gauge
+Unit: byte_in_binary_bytes_family
+```
+
 ### k8s.pod.network.io
 ```
 Metric Type: Gauge

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -82,6 +82,7 @@ config:
           - service.name
           - service.version
           - service.instance.id
+          - container.id
       passthrough: false
 
     # the order of resource detection is important as it will influence how attributes


### PR DESCRIPTION
### What does this PR do?
Updates the README to set the correct unit for `k8s.pod.memory.usage` and adds the `container.id` attribute to the k8sattributesprocessor is enriches container metrics with their respective IDs.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
