### PR TITLE
Add @codex to default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for syntax
 
-*              @DataDog/opentelemetry
+*              @DataDog/opentelemetry @codex


### PR DESCRIPTION
### Motivation
- Ensure Codex is automatically requested as a reviewer on pull requests by adding it to the repository's default code owners.

### Description
- Updated `.github/CODEOWNERS` to include `@codex` alongside `@DataDog/opentelemetry` for the default rule covering all files.

### Testing
- No automated tests were run because this change only updates repository metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7881923448333ba585e14d5753c3e)