### PR TITLE
fix: bump Go base image to 1.25 in calendar Dockerfile

### DIFF
--- a/apps/rpc/golang/Dockerfile.calendar.go.otel
+++ b/apps/rpc/golang/Dockerfile.calendar.go.otel
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache 2.0 License.
 #
-FROM golang:1.22
+FROM golang:1.25
 
 
 WORKDIR /app

--- a/apps/rpc/golang/calendar-otel/main.go
+++ b/apps/rpc/golang/calendar-otel/main.go
@@ -133,8 +133,7 @@ func realMain() error {
 
 	logger.Info("Starting on port ", zap.String("port", port))
 	grpcServer := grpc.NewServer(
-		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
-		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.StatsHandler(new(ocgrpc.ServerHandler)),
 	)
 	reflection.Register(grpcServer)

--- a/apps/rpc/golang/calendar-otel/server.go
+++ b/apps/rpc/golang/calendar-otel/server.go
@@ -16,7 +16,6 @@ import (
 type Server struct {
 	*health.Server
 	calendarpb.UnimplementedCalendarServiceServer
-	healthpb.UnimplementedHealthServer
 }
 
 func (s *Server) GetRandomDate(


### PR DESCRIPTION
## Summary

Three build failures fixed in the Go calendar-otel app:

- **Dockerfile**: bumped base image from `golang:1.22` → `golang:1.25` to match `go.mod`
- **main.go**: replaced removed `otelgrpc` interceptors with the current `NewServerHandler()` stats handler API
- **server.go**: removed redundant `UnimplementedHealthServer` embed that caused an ambiguous selector compile error

## Test plan
- [ ] `docker build --file Dockerfile.calendar.go.otel --tag otel-demo:calendar-go-otel .` succeeds
- [ ] Built image runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)