### PR TITLE
[OTEL-2912] Add back system detector in containers

### DIFF
--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -69,11 +69,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -52,9 +52,30 @@ receivers:
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resourcedetection:
-    detectors: [env]
+    detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
+    system:
+      resource_attributes:
+        host.name:
+          enabled: false # Containers report inaccurate host names
+    # Uncomment this section if you want to get additional metadata about your host
+    #     host.arch:
+    #       enabled: true
+    #     host.cpu.cache.l2.size:
+    #       enabled: true
+    #     host.cpu.family:
+    #       enabled: true
+    #     host.cpu.model.id:
+    #       enabled: true
+    #     host.cpu.model.name:
+    #       enabled: true
+    #     host.cpu.stepping:
+    #       enabled: true
+    #     host.cpu.vendor.id:
+    #       enabled: true
+    #     os.description:
+    #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints
   cumulativetodelta: {}

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -69,11 +69,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -69,11 +69,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -69,11 +69,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -72,7 +72,7 @@ receivers:
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resourcedetection:
-    detectors: [eks, ec2, env]
+    detectors: [eks, ec2, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
     eks:
@@ -80,6 +80,27 @@ processors:
         k8s.cluster.name: { enabled: true }
     ec2:
       tags: ['^kubernetes\.io/cluster/.*$']
+    system:
+      resource_attributes:
+        host.name:
+          enabled: false # Containers report inaccurate host names
+    # Uncomment this section if you want to get additional metadata about your host
+    #     host.arch:
+    #       enabled: true
+    #     host.cpu.cache.l2.size:
+    #       enabled: true
+    #     host.cpu.family:
+    #       enabled: true
+    #     host.cpu.model.id:
+    #       enabled: true
+    #     host.cpu.model.name:
+    #       enabled: true
+    #     host.cpu.stepping:
+    #       enabled: true
+    #     host.cpu.vendor.id:
+    #       enabled: true
+    #     os.description:
+    #       enabled: true
   k8s_attributes:
     # Requires setting up ServiceAccount, (Cluster)Role, and (Cluster)RoleBinding resources
     # See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor#role-based-access-control

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -73,9 +73,30 @@ receivers:
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resourcedetection:
-    detectors: [env]
+    detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
+    system:
+      resource_attributes:
+        host.name:
+          enabled: false # Containers report inaccurate host names
+    # Uncomment this section if you want to get additional metadata about your host
+    #     host.arch:
+    #       enabled: true
+    #     host.cpu.cache.l2.size:
+    #       enabled: true
+    #     host.cpu.family:
+    #       enabled: true
+    #     host.cpu.model.id:
+    #       enabled: true
+    #     host.cpu.model.name:
+    #       enabled: true
+    #     host.cpu.stepping:
+    #       enabled: true
+    #     host.cpu.vendor.id:
+    #       enabled: true
+    #     os.description:
+    #       enabled: true
   k8s_attributes:
     # Requires setting up ServiceAccount, (Cluster)Role, and (Cluster)RoleBinding resources
     # See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor#role-based-access-control

--- a/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
@@ -1,22 +1,18 @@
 {{- /* TODO: Implement AKS, Azure, ECS, GKE environments */}}
-{{- $system := ", system"}}
-{{- if .Container}}
-{{- $system = ""}}
-{{- end}}
 {{- $kubeadm := ""}}
 {{- if .K8sObjects}}
 {{- $kubeadm = ", kubeadm"}}
 {{- end}}
 {{- if eq .CloudEnvironment "ec2"}}
-detectors: [ec2, env{{$kubeadm}}{{$system}}]
+detectors: [ec2, env{{$kubeadm}}, system]
 {{- else if eq .CloudEnvironment "eks" }}
-detectors: [eks, ec2, env{{$kubeadm}}{{$system}}]
+detectors: [eks, ec2, env{{$kubeadm}}, system]
 {{- else if eq .CloudEnvironment "gce" }}
-detectors: [gcp, env{{$kubeadm}}{{$system}}]
+detectors: [gcp, env{{$kubeadm}}, system]
 {{- else if eq .CloudEnvironment "azure" }}
-detectors: [azure, env{{$kubeadm}}{{$system}}]
+detectors: [azure, env{{$kubeadm}}, system]
 {{- else if eq .CloudEnvironment "" }}
-detectors: [env{{$kubeadm}}{{$system}}]
+detectors: [env{{$kubeadm}}, system]
 {{- else }}
 {{- errorf "unknown cloud environment %q" .CloudEnvironment}}
 {{- end}}
@@ -41,10 +37,17 @@ eks:
 ec2:
   tags: ['^kubernetes\.io/cluster/.*$']
 {{- end}}
-{{- if not .Container}}
+{{- if .Container}}
+system:
+  resource_attributes:
+    host.name:
+      enabled: false # Containers report inaccurate host names
+# Uncomment this section if you want to get additional metadata about your host
+{{- else}}
 # Uncomment this section if you want to get additional metadata about your host
 # system:
 #   resource_attributes:
+{{- end}}
 #     host.arch:
 #       enabled: true
 #     host.cpu.cache.l2.size:
@@ -59,10 +62,11 @@ ec2:
 #       enabled: true
 #     host.cpu.vendor.id:
 #       enabled: true
+#     os.description:
+#       enabled: true
+{{- if not .Container}} {{- /* Containers report inaccurate network information */}}
 #     host.ip:
 #       enabled: true
 #     host.mac:
-#       enabled: true
-#     os.description:
 #       enabled: true
 {{- end}}

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -126,7 +126,7 @@ alternateConfig:
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
     resourcedetection:
-      detectors: [eks, ec2, env]
+      detectors: [eks, ec2, env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       eks:
@@ -134,6 +134,27 @@ alternateConfig:
           k8s.cluster.name: { enabled: true }
       ec2:
         tags: ['^kubernetes\.io/cluster/.*$']
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
     k8s_attributes:
       extract:
         otel_annotations: true

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -129,9 +129,30 @@ alternateConfig:
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
     resourcedetection:
-      detectors: [env]
+      detectors: [env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
     k8s_attributes:
       extract:
         otel_annotations: true

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -340,7 +340,7 @@ alternateConfig:
         metric:
           - metric.name == "kube_service_spec_type"
     resourcedetection:
-      detectors: [eks, ec2, env, kubeadm]
+      detectors: [eks, ec2, env, kubeadm, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
@@ -353,6 +353,27 @@ alternateConfig:
           k8s.cluster.name: { enabled: true }
       ec2:
         tags: ['^kubernetes\.io/cluster/.*$']
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
   connectors:
     # The count connector generates custom metrics by counting the number
     # of metric series.

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -350,7 +350,7 @@ alternateConfig:
           value: "${env:OTEL_K8S_CLUSTER_NAME}"
           action: upsert
     resourcedetection:
-      detectors: [env, kubeadm]
+      detectors: [env, kubeadm, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
@@ -358,6 +358,27 @@ alternateConfig:
         resource_attributes:
           k8s.cluster.name:
             enabled: false
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
   connectors:
     # The count connector generates custom metrics by counting the number
     # of metric series.

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -302,11 +302,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 connectors:
   # The count connector generates custom metrics by counting the number

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -305,11 +305,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 connectors:
   # The count connector generates custom metrics by counting the number

--- a/configurations/opentelemetry-collector/testing/agent-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/agent-datadog.yaml
@@ -70,11 +70,11 @@ processors:
     #       enabled: true
     #     host.cpu.vendor.id:
     #       enabled: true
+    #     os.description:
+    #       enabled: true
     #     host.ip:
     #       enabled: true
     #     host.mac:
-    #       enabled: true
-    #     os.description:
     #       enabled: true
 
   # Transform metrics to fit Datadog platform constraints

--- a/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
@@ -53,9 +53,30 @@ receivers:
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resourcedetection:
-    detectors: [env]
+    detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
+    system:
+      resource_attributes:
+        host.name:
+          enabled: false # Containers report inaccurate host names
+    # Uncomment this section if you want to get additional metadata about your host
+    #     host.arch:
+    #       enabled: true
+    #     host.cpu.cache.l2.size:
+    #       enabled: true
+    #     host.cpu.family:
+    #       enabled: true
+    #     host.cpu.model.id:
+    #       enabled: true
+    #     host.cpu.model.name:
+    #       enabled: true
+    #     host.cpu.stepping:
+    #       enabled: true
+    #     host.cpu.vendor.id:
+    #       enabled: true
+    #     os.description:
+    #       enabled: true
   k8s_attributes:
     # Requires setting up ServiceAccount, (Cluster)Role, and (Cluster)RoleBinding resources
     # See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor#role-based-access-control

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -341,7 +341,7 @@ alternateConfig:
         metric:
           - metric.name == "kube_service_spec_type"
     resourcedetection:
-      detectors: [eks, ec2, env, kubeadm]
+      detectors: [eks, ec2, env, kubeadm, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
@@ -354,6 +354,27 @@ alternateConfig:
           k8s.cluster.name: { enabled: true }
       ec2:
         tags: ['^kubernetes\.io/cluster/.*$']
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
   connectors:
     # The count connector generates custom metrics by counting the number
     # of metric series.

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -351,7 +351,7 @@ alternateConfig:
           value: "${env:OTEL_K8S_CLUSTER_NAME}"
           action: upsert
     resourcedetection:
-      detectors: [env, kubeadm]
+      detectors: [env, kubeadm, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
@@ -359,6 +359,27 @@ alternateConfig:
         resource_attributes:
           k8s.cluster.name:
             enabled: false
+      system:
+        resource_attributes:
+          host.name:
+            enabled: false # Containers report inaccurate host names
+      # Uncomment this section if you want to get additional metadata about your host
+      #     host.arch:
+      #       enabled: true
+      #     host.cpu.cache.l2.size:
+      #       enabled: true
+      #     host.cpu.family:
+      #       enabled: true
+      #     host.cpu.model.id:
+      #       enabled: true
+      #     host.cpu.model.name:
+      #       enabled: true
+      #     host.cpu.stepping:
+      #       enabled: true
+      #     host.cpu.vendor.id:
+      #       enabled: true
+      #     os.description:
+      #       enabled: true
   connectors:
     # The count connector generates custom metrics by counting the number
     # of metric series.

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
@@ -172,7 +172,7 @@ opentelemetry-collector:
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
       resourcedetection:
-        detectors: [eks, ec2, env]
+        detectors: [eks, ec2, env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
         eks:
@@ -180,6 +180,27 @@ opentelemetry-collector:
             k8s.cluster.name: { enabled: true }
         ec2:
           tags: ['^kubernetes\.io/cluster/.*$']
+        system:
+          resource_attributes:
+            host.name:
+              enabled: false # Containers report inaccurate host names
+        # Uncomment this section if you want to get additional metadata about your host
+        #     host.arch:
+        #       enabled: true
+        #     host.cpu.cache.l2.size:
+        #       enabled: true
+        #     host.cpu.family:
+        #       enabled: true
+        #     host.cpu.model.id:
+        #       enabled: true
+        #     host.cpu.model.name:
+        #       enabled: true
+        #     host.cpu.stepping:
+        #       enabled: true
+        #     host.cpu.vendor.id:
+        #       enabled: true
+        #     os.description:
+        #       enabled: true
       k8s_attributes:
         extract:
           otel_annotations: true

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
@@ -175,9 +175,30 @@ opentelemetry-collector:
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
       resourcedetection:
-        detectors: [env]
+        detectors: [env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
+        system:
+          resource_attributes:
+            host.name:
+              enabled: false # Containers report inaccurate host names
+        # Uncomment this section if you want to get additional metadata about your host
+        #     host.arch:
+        #       enabled: true
+        #     host.cpu.cache.l2.size:
+        #       enabled: true
+        #     host.cpu.family:
+        #       enabled: true
+        #     host.cpu.model.id:
+        #       enabled: true
+        #     host.cpu.model.name:
+        #       enabled: true
+        #     host.cpu.stepping:
+        #       enabled: true
+        #     host.cpu.vendor.id:
+        #       enabled: true
+        #     os.description:
+        #       enabled: true
       k8s_attributes:
         extract:
           otel_annotations: true

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -148,7 +148,7 @@ opentelemetry-collector:
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
       resourcedetection:
-        detectors: [eks, ec2, env]
+        detectors: [eks, ec2, env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
         eks:
@@ -156,6 +156,27 @@ opentelemetry-collector:
             k8s.cluster.name: { enabled: true }
         ec2:
           tags: ['^kubernetes\.io/cluster/.*$']
+        system:
+          resource_attributes:
+            host.name:
+              enabled: false # Containers report inaccurate host names
+        # Uncomment this section if you want to get additional metadata about your host
+        #     host.arch:
+        #       enabled: true
+        #     host.cpu.cache.l2.size:
+        #       enabled: true
+        #     host.cpu.family:
+        #       enabled: true
+        #     host.cpu.model.id:
+        #       enabled: true
+        #     host.cpu.model.name:
+        #       enabled: true
+        #     host.cpu.stepping:
+        #       enabled: true
+        #     host.cpu.vendor.id:
+        #       enabled: true
+        #     os.description:
+        #       enabled: true
       k8s_attributes:
         extract:
           otel_annotations: true

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -151,9 +151,30 @@ opentelemetry-collector:
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
       resourcedetection:
-        detectors: [env]
+        detectors: [env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
+        system:
+          resource_attributes:
+            host.name:
+              enabled: false # Containers report inaccurate host names
+        # Uncomment this section if you want to get additional metadata about your host
+        #     host.arch:
+        #       enabled: true
+        #     host.cpu.cache.l2.size:
+        #       enabled: true
+        #     host.cpu.family:
+        #       enabled: true
+        #     host.cpu.model.id:
+        #       enabled: true
+        #     host.cpu.model.name:
+        #       enabled: true
+        #     host.cpu.stepping:
+        #       enabled: true
+        #     host.cpu.vendor.id:
+        #       enabled: true
+        #     os.description:
+        #       enabled: true
       k8s_attributes:
         extract:
           otel_annotations: true


### PR DESCRIPTION
### What does this PR do?

After some additional testing, the CPU information gathered by the system resource detector seems to be accurate even in containers / in Kubernetes. The host name and network information however, is local to the container, and is thus not useful as host metadata. Thus, this PR adds back the system detector in all configurations, but disables `host.name` and does not suggest network-related attributes in containers.
