### PR TITLE
Use regular OTLP metrics endpoint

### DIFF
--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -182,7 +182,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -162,7 +162,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -182,7 +182,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -182,7 +182,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -182,7 +182,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -229,7 +229,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -225,7 +225,6 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -1,5 +1,4 @@
 endpoint: https://otlp.${env:DD_SITE}
-metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics {{- /* TODO: Remove this */}}
 headers:
   dd-api-key: ${env:DD_API_KEY}
   # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -281,7 +281,6 @@ alternateConfig:
     # Send telemetry to Datadog's OTLP intake endpoints
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -279,7 +279,6 @@ alternateConfig:
     # Send telemetry to Datadog's OTLP intake endpoints
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -406,7 +406,6 @@ alternateConfig:
         enabled: true
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -411,7 +411,6 @@ alternateConfig:
         enabled: true
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -361,7 +361,6 @@ exporters:
       enabled: true
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -364,7 +364,6 @@ exporters:
       enabled: true
   otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
-    metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
     headers:
       dd-api-key: ${env:DD_API_KEY}
       # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -407,7 +407,6 @@ alternateConfig:
         enabled: true
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -412,7 +412,6 @@ alternateConfig:
         enabled: true
     otlp_http:
       endpoint: https://otlp.${env:DD_SITE}
-      metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
       headers:
         dd-api-key: ${env:DD_API_KEY}
         # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -337,7 +337,6 @@ opentelemetry-collector:
       # Send telemetry to Datadog's OTLP intake endpoints
       otlp_http:
         endpoint: https://otlp.${env:DD_SITE}
-        metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
         headers:
           dd-api-key: ${env:DD_API_KEY}
           # Send resource attributes and scope metadata as metric tags

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -335,7 +335,6 @@ opentelemetry-collector:
       # Send telemetry to Datadog's OTLP intake endpoints
       otlp_http:
         endpoint: https://otlp.${env:DD_SITE}
-        metrics_endpoint: https://otlp.${env:DD_SITE}/api/v2/otlpmetrics
         headers:
           dd-api-key: ${env:DD_API_KEY}
           # Send resource attributes and scope metadata as metric tags


### PR DESCRIPTION
### What does this PR do?

It's now assumed that anyone using the recommended config is on an org with the routing necessary to use the OTLP intake platform under `/v1/metrics` instead of `/api/v2/otlpmetrics`