### PR TITLE
[OTEL-3042] Dual ship OSS demo telemetry

### DIFF
--- a/configurations/opentelemetry-collector/generator/configs.go
+++ b/configurations/opentelemetry-collector/generator/configs.go
@@ -18,5 +18,5 @@ var configs = []config{
 	{"testing/helm-k8s-objects-datadog", "helm-k8s-objects", []string{"", "eks"}, map[string]any{"Deployment": true, "DatadogExporter": true, "KSM": true, "K8sObjects": true, "Testing": true}},
 	{"testing/daemonset-datadog", "otelcol-agent", []string{""}, map[string]any{"Container": true, "K8s": true, "DatadogExporter": true, "Testing": true}},
 	{"testing/otel-demo-datadog", "otel-demo", []string{"", "eks"}, map[string]any{"DatadogExporter": true, "Testing": true, "ExperimentalRuntimeMetrics": true, "MapEquivalentMetrics": true, "KubeletStats": true}},
-	{"testing/otel-demo", "otel-demo", []string{"", "eks"}, map[string]any{"Testing": true, "ExperimentalRuntimeMetrics": true, "MapEquivalentMetrics": true}},
+	{"testing/otel-demo", "otel-demo", []string{"", "eks"}, map[string]any{"Testing": true, "ExperimentalRuntimeMetrics": true, "MapEquivalentMetrics": true, "DualShip": true}},
 }

--- a/configurations/opentelemetry-collector/generator/templates/components/datadog-extension.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/datadog-extension.tmpl
@@ -1,4 +1,5 @@
+{{if not .EnvSuffix}}{{set . "EnvSuffix" ""}}{{end}}
 api:
-  site: ${env:DD_SITE}
-  key: ${env:DD_API_KEY}
+  site: ${env:DD_SITE{{.EnvSuffix}}}
+  key: ${env:DD_API_KEY{{.EnvSuffix}}}
 deployment_type: daemonset

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -1,6 +1,7 @@
-endpoint: https://otlp.${env:DD_SITE}
+{{if not .EnvSuffix}}{{set . "EnvSuffix" ""}}{{end}}
+endpoint: https://otlp.${env:DD_SITE{{.EnvSuffix}}}
 headers:
-  dd-api-key: ${env:DD_API_KEY}
+  dd-api-key: ${env:DD_API_KEY{{.EnvSuffix}}}
   # Send resource attributes and scope metadata as metric tags
   dd-otel-metric-config: >-
     {

--- a/configurations/opentelemetry-collector/generator/templates/helm-daemonset.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/helm-daemonset.tmpl
@@ -16,6 +16,15 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secrets
         key: api-key
+  {{- if .DualShip}}
+  - name: DD_SITE_DUAL_SHIP
+    value: datadoghq.com # Update if necessary
+  - name: DD_API_KEY_DUAL_SHIP
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secrets-dual-ship
+        key: api-key
+  {{- end}}
   {{- if eq .CloudEnvironment ""}}
   # Use the K8s-related variables predefined by the Helm chart
   - name: OTEL_RESOURCE_ATTRIBUTES

--- a/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
@@ -133,6 +133,11 @@ extensions:
   # Report Collector status to Datadog for Fleet Automation
   datadog:
     {{include "datadog-extension" . | indent 4}}
+  {{- if .DualShip}}
+  datadog/dual_ship:
+    {{- set . "EnvSuffix" "_DUAL_SHIP"}}
+    {{include "datadog-extension" . | indent 4}}
+  {{- end}}
 
 service:
   extensions:
@@ -140,6 +145,9 @@ service:
     - health_check # May be necessary for liveness/readiness probe
     {{- end}}
     - datadog
+    {{- if .DualShip}}
+    - datadog/dual_ship
+    {{- end}}
   
   pipelines:
     logs:

--- a/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
@@ -118,6 +118,11 @@ exporters:
   # Send telemetry to Datadog's OTLP intake endpoints
   otlp_http:
     {{include "otlp-http-exporter" . | indent 4}}
+  {{- if .DualShip}}
+  otlp_http/dual_ship:
+    {{- set . "EnvSuffix" "_DUAL_SHIP"}}
+    {{include "otlp-http-exporter" . | indent 4}}
+  {{- end}}
   {{- end}}
 
 extensions:
@@ -146,6 +151,8 @@ service:
         - resourcedetection
       {{- if .DatadogExporter}}
       exporters: [datadog]
+      {{- else if .DualShip}}
+      exporters: [otlp_http, otlp_http/dual_ship]
       {{- else}}
       exporters: [otlp_http]
       {{- end}}
@@ -180,6 +187,8 @@ service:
     {{- end}}
       {{- if .DatadogExporter}}
       exporters: [datadog]
+      {{- else if .DualShip}}
+      exporters: [otlp_http, otlp_http/dual_ship]
       {{- else}}
       exporters: [otlp_http]
       {{- end}}
@@ -210,11 +219,19 @@ service:
     traces/sample:
       receivers: [forward/traces_sample]
       # Add sampling processors here (for example, tail_sampling) before exporting traces
+      {{- if .DualShip}}
+      exporters: [otlp_http, otlp_http/dual_ship]
+      {{- else}}
       exporters: [otlp_http]
+      {{- end}}
     
     metrics/span_metrics:
       receivers: [span_metrics]
+      {{- if .DualShip}}
+      exporters: [otlp_http, otlp_http/dual_ship]
+      {{- else}}
       exporters: [otlp_http]
+      {{- end}}
     {{- end}}
   
   telemetry:

--- a/configurations/opentelemetry-collector/testing/README.md
+++ b/configurations/opentelemetry-collector/testing/README.md
@@ -21,9 +21,13 @@ The [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo) i
 The following files are `values.yaml` files to be passed as a `--values` flag when deploying the Demo Helm chart.
 These will deploy a mostly vanilla version of the OpenTelemetry Demo, whose telemetry is exported via a Daemonset Collector using one of the above recommended configurations.
 
+The current testing configuration has experimental flags enabled to dual ship the data to two orgs, and to transform metrics to enable equivalences for runtime metrics.
+
 Example:
 ```sh
-kubectl create secret generic datadog-secrets --from-literal=api-key='insertyourapikey'
+# Update DD_SITE, DD_SITE_DUAL_SHIP, and deployment.environment.name in ./testing/otel-demo.yaml
+kubectl create secret generic datadog-secrets --from-literal=api-key='insertyourapikey' \
+  --from-literal=api-key-dual-ship='insertyourapikey'
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install otel-demo open-telemetry/opentelemetry-demo --values ./testing/otel-demo.yaml
 ```

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -57,6 +57,13 @@ opentelemetry-collector:
         secretKeyRef:
           name: datadog-secrets
           key: api-key
+    - name: DD_SITE_DUAL_SHIP
+      value: datadoghq.com # Update if necessary
+    - name: DD_API_KEY_DUAL_SHIP
+      valueFrom:
+        secretKeyRef:
+          name: datadog-secrets-dual-ship
+          key: api-key
   
   mode: daemonset
   image:
@@ -371,6 +378,21 @@ opentelemetry-collector:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
           batch: {} # Default batch settings
+      otlp_http/dual_ship:
+        endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
+        headers:
+          dd-api-key: ${env:DD_API_KEY_DUAL_SHIP}
+          # Send resource attributes and scope metadata as metric tags
+          dd-otel-metric-config: >-
+            {
+            "resource_attributes_as_tags": true,
+            "instrumentation_scope_metadata_as_tags": true
+            }
+        compression: zstd
+        compression_params:
+          level: 3 # Level must be set explicitly for zstd
+        sending_queue:
+          batch: {} # Default batch settings
     
     extensions:
       health_check:
@@ -393,7 +415,7 @@ opentelemetry-collector:
           processors:
             - k8s_attributes
             - resourcedetection
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics:
           receivers: [otlp, host_metrics]
@@ -415,7 +437,7 @@ opentelemetry-collector:
             - cumulativetodelta
             - deltatorate
             - transform/rate_to_gauge
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         traces:
           receivers: [otlp]
@@ -427,11 +449,11 @@ opentelemetry-collector:
         traces/sample:
           receivers: [forward/traces_sample]
           # Add sampling processors here (for example, tail_sampling) before exporting traces
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics/span_metrics:
           receivers: [span_metrics]
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
       
       telemetry:
         # Route Collector internal metrics through its own pipelines for enrichment purposes

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -400,14 +400,20 @@ opentelemetry-collector:
       # Report Collector status to Datadog for Fleet Automation
       datadog:
         api:
-          site: ${env:DD_SITE}
-          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE_DUAL_SHIP}
+          key: ${env:DD_API_KEY_DUAL_SHIP}
+        deployment_type: daemonset
+      datadog/dual_ship:
+        api:
+          site: ${env:DD_SITE_DUAL_SHIP}
+          key: ${env:DD_API_KEY_DUAL_SHIP}
         deployment_type: daemonset
     
     service:
       extensions:
         - health_check # May be necessary for liveness/readiness probe
         - datadog
+        - datadog/dual_ship
       
       pipelines:
         logs:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -398,14 +398,20 @@ opentelemetry-collector:
       # Report Collector status to Datadog for Fleet Automation
       datadog:
         api:
-          site: ${env:DD_SITE}
-          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE_DUAL_SHIP}
+          key: ${env:DD_API_KEY_DUAL_SHIP}
+        deployment_type: daemonset
+      datadog/dual_ship:
+        api:
+          site: ${env:DD_SITE_DUAL_SHIP}
+          key: ${env:DD_API_KEY_DUAL_SHIP}
         deployment_type: daemonset
     
     service:
       extensions:
         - health_check # May be necessary for liveness/readiness probe
         - datadog
+        - datadog/dual_ship
       
       pipelines:
         logs:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -57,6 +57,13 @@ opentelemetry-collector:
         secretKeyRef:
           name: datadog-secrets
           key: api-key
+    - name: DD_SITE_DUAL_SHIP
+      value: datadoghq.com # Update if necessary
+    - name: DD_API_KEY_DUAL_SHIP
+      valueFrom:
+        secretKeyRef:
+          name: datadog-secrets-dual-ship
+          key: api-key
     # Use the K8s-related variables predefined by the Helm chart
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: "k8s.node.name=$(OTEL_K8S_NODE_NAME)"
@@ -369,6 +376,21 @@ opentelemetry-collector:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
           batch: {} # Default batch settings
+      otlp_http/dual_ship:
+        endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
+        headers:
+          dd-api-key: ${env:DD_API_KEY_DUAL_SHIP}
+          # Send resource attributes and scope metadata as metric tags
+          dd-otel-metric-config: >-
+            {
+            "resource_attributes_as_tags": true,
+            "instrumentation_scope_metadata_as_tags": true
+            }
+        compression: zstd
+        compression_params:
+          level: 3 # Level must be set explicitly for zstd
+        sending_queue:
+          batch: {} # Default batch settings
     
     extensions:
       health_check:
@@ -391,7 +413,7 @@ opentelemetry-collector:
           processors:
             - k8s_attributes
             - resourcedetection
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics:
           receivers: [otlp, host_metrics]
@@ -413,7 +435,7 @@ opentelemetry-collector:
             - cumulativetodelta
             - deltatorate
             - transform/rate_to_gauge
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         traces:
           receivers: [otlp]
@@ -425,11 +447,11 @@ opentelemetry-collector:
         traces/sample:
           receivers: [forward/traces_sample]
           # Add sampling processors here (for example, tail_sampling) before exporting traces
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics/span_metrics:
           receivers: [span_metrics]
-          exporters: [otlp_http]
+          exporters: [otlp_http, otlp_http/dual_ship]
       
       telemetry:
         # Route Collector internal metrics through its own pipelines for enrichment purposes


### PR DESCRIPTION
### What does this PR do?

Adds a config generator flag to generate two `otlp_http` exporters with different sites / API keys. This is used in the `testing/otel-demo` config for dual shipping purposes.