### PR TITLE
Stop requiring users to manually set the cluster name in Kubernetes collector configs

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -123,7 +123,7 @@ spec:
 <blockquote> NOTE: If you are incorporating the configuration files found in [/configuration](/documentation/kubernetes/configuration/) into your existing OpenTelemetry collector deployment, please be aware that they are specifically written for
 
 * [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart 
-* OTel image `otel/opentelemetry-collector-contrib` >= `0.130.0`
+* OTel image `otel/opentelemetry-collector-contrib` >= `0.152.0`
 
 </blockquote>
 
@@ -158,16 +158,16 @@ helm repo update
 # Install the Daemonset Collector
 helm install otel-daemon-collector open-telemetry/opentelemetry-collector -f configuration/daemonset-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.130.0
+  --set image.tag=0.152.0
 
 # Install the Cluster Collector
 helm install otel-cluster-collector open-telemetry/opentelemetry-collector -f configuration/cluster-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.130.0
+  --set image.tag=0.152.0
 ```
 
 > [!NOTE]
-> The cluster name is automatically detected from the cloud environment (EKS, AKS, GKE) via the `resourcedetection` processor. See the [cluster-name detection docs][16] for supported providers. If your cloud provider is not supported, uncomment the `resource/add-cluster-name` processor block in both configuration files and set your cluster name there.
+> The cluster name is automatically detected from the cloud environment (EKS, AKS, GKE) via the `resourcedetection` processor. See the [cluster-name detection docs][16] for supported providers. If your cloud provider is not supported, in both configuration files: (1) uncomment the `resource/add-cluster-name` processor block and set your cluster name, and (2) add `resource/add-cluster-name` to the `processors` list in the metrics pipeline.
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 [2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver

--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -24,10 +24,10 @@ Many of the metrics collected for the Kubernetes integration report on the _over
 | receiver    | [prometheus][1]         | Scrapes your cluster's kube-state-metrics endpoint |
 | receiver    | [k8s_cluster][2]        | Collects additional cluster-level metrics |
 | processor   | [cumulativetodelta][4]  | Converts monotonic, cumulative sum and histogram metrics to monotonic, delta metrics |
-| processor   | [resource][5]           | Globally sets the `k8s.cluster.name` attribute on resources for tagging purposes |
+| processor   | [resourcedetection][14] | Automatically detects [`k8s.cluster.name`][16] (EKS/AKS/GKE) and `k8s.cluster.uid` (kubeadm) |
 | processor   | [transform][6]          | Modifies, adds, and deletes resource/datapoint attributes |
 | processor   | [groupbyattrs][7]       | Associates kube-state-metrics Pod datapoints with the correct OTel resource by Pod UID |
-| processor   | [k8sattributes][8]      | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
+| processor   | [k8s_attributes][8]     | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
 | connector   | [count][9]              | Counts Kubernetes metrics to generate `k8s.node.count`, `k8s.job.count`, and `k8s.service.count` |
 | exporter    | [datadog][10]           | Ships telemetry to Datadog |
 
@@ -38,10 +38,8 @@ Many of the metrics collected for the Kubernetes integration report on the _over
 | receiver    | [kubeletstats][12]      | Collects node, pod, container, and volume metrics from the Kubelet |
 | processor   | [cumulativetodelta][4]  | Converts monotonic, cumulative sum and histogram metrics to monotonic, delta metrics |
 | processor   | [deltatorate][13]       | Converts delta sum metrics to rate metrics that are sent as gauges |
-| processor   | [resource][5]           | Globally sets the `k8s.cluster.name` attribute on resources for tagging purposes |
-| processor   | [transform][6]          | Modifies, adds, and deletes resource/datapoint attributes |
-| processor   | [k8sattributes][8]      | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
-| processor   | [resourcedetection][14] | Detects environment information from a variety of sources |
+| processor   | [resourcedetection][14] | Automatically detects [`k8s.cluster.name`][16] (EKS/AKS/GKE) and `k8s.cluster.uid` (kubeadm) |
+| processor   | [k8s_attributes][8]     | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
 | connector   | [datadog/connector][15] | Converts OTel traces into Datadog compatible traces for consumption in Datadog's APM products |
 | exporter    | [datadog][10]           | Ships telemetry to Datadog |
 
@@ -157,31 +155,23 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm repo update
 ```
 ```bash
-# Export your cluster name
-export K8S_CLUSTER_NAME=<YOUR CLUSTER NAME HERE>
-```
-
-```bash
-# Install the Daemonset Collector 
+# Install the Daemonset Collector
 helm install otel-daemon-collector open-telemetry/opentelemetry-collector -f configuration/daemonset-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.130.0 \
-  --set-string "config.processors.resource.attributes[0].key=k8s.cluster.name" \
-  --set-string "config.processors.resource.attributes[0].value=${K8S_CLUSTER_NAME}"
-
+  --set image.tag=0.130.0
 
 # Install the Cluster Collector
 helm install otel-cluster-collector open-telemetry/opentelemetry-collector -f configuration/cluster-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.130.0 \
-  --set-string "config.processors.resource.attributes[0].key=k8s.cluster.name" \
-  --set-string "config.processors.resource.attributes[0].value=${K8S_CLUSTER_NAME}"
+  --set image.tag=0.130.0
 ```
+
+> [!NOTE]
+> The cluster name is automatically detected from the cloud environment (EKS, AKS, GKE) via the `resourcedetection` processor. See the [cluster-name detection docs][16] for supported providers. If your cloud provider is not supported, uncomment the `resource/add-cluster-name` processor block in both configuration files and set your cluster name there.
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 [2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver
 [4]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor
-[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor
 [6]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
 [7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor
 [8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
@@ -192,4 +182,5 @@ helm install otel-cluster-collector open-telemetry/opentelemetry-collector -f co
 [13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatorateprocessor
 [14]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 [15]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector
+[16]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.152.0/processor/resourcedetectionprocessor#cluster-name
 

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -38,13 +38,6 @@ config:
 
   processors:
     cumulativetodelta: {}
-    resource:
-      attributes:
-        # Globally set k8s cluster name on all resources
-        - key: k8s.cluster.name
-          value: <YOUR K8S CLUSTER NAME HERE>
-          action: "insert"
-    
     # Rename KSM metric prometheus label uid -> k8s.pod.uid to adhere to OTel standard and
     # facililtate the groupby specified below.
     transform/rename_uid:
@@ -54,7 +47,7 @@ config:
             - set(attributes["k8s.pod.uid"], attributes["uid"])
             - delete_key(attributes, "uid")
         # We have to delete these from the resource because they were incorrectly 
-        # set by the prometheus receiver, k8sattributes will repopulate them but
+        # set by the prometheus receiver, k8s_attributes will repopulate them but
         # cannot overwrite them.
         - context: resource
           statements:
@@ -105,8 +98,8 @@ config:
             - set(attributes["kube_service"], attributes["service"])
             - delete_key(attributes, "service")
     
-    # k8sattributesprocessor is used to enrich metrics with additional metadata, namely, service.
-    k8sattributes:
+    # k8s_attributesprocessor is used to enrich metrics with additional metadata, namely, service.
+    k8s_attributes:
       auth_type: "serviceAccount"
       extract:
         otel_annotations: true
@@ -119,18 +112,23 @@ config:
           - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
           - k8s.container.name
+          - service.namespace
           - service.name
           - service.version
           - service.instance.id
-      passthrough: false
+          - container.id
+          - container.image.name
+          - container.image.tag
       # By default association is done via Pod IP, we need to override
-      # this so it doesn't erroneously associate metrics with the 
+      # this so it doesn't erroneously associate metrics with the
       # kube-state-metrics pod.
       pod_association:
         - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
+            - from: resource_attribute
+              name: k8s.pod.uid
     
     transform/sum_to_gauge:
       metric_statements:
@@ -143,6 +141,40 @@ config:
       metrics:
         metric:
           - metric.name == "kube_service_spec_type"
+    
+    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
+    # Adjust the k8s.cluster.name settings below for your cloud provider.
+    # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
+    # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.152.0/processor/resourcedetectionprocessor#cluster-name
+    resourcedetection:
+      detectors: ["k8snode", "system", "ec2", "eks", "aks", "gcp", "kubeadm"]
+      override: false
+      # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
+      # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.
+      # If running on a kubeadm cluster, set k8s.cluster.name.enabled to true.
+      kubeadm:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: false
+      eks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+      aks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+      gcp:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+
+    # Manually inject the cluster name if your cloud provider is not supported by the resourcedetection processor.
+    # resource/add-cluster-name:
+    #   attributes:
+    #     - key: k8s.cluster.name
+    #       value: <YOUR_CLUSTER_NAME>
+    #       action: upsert
   
   connectors:
     # The count connector helps us generate three custom metrics by counting the number 
@@ -151,7 +183,6 @@ config:
     # 2. k8s.node.count
     # 3. k8s.job.count
     count:
-      aggregation_interval: 10s
       datapoints:
         k8s.service.count:
           # k8s.service.count is grouped by namespace and type
@@ -185,5 +216,5 @@ config:
         
       metrics:
         receivers: [otlp, prometheus, count]
-        processors: [filter/ksm, resource, transform/ksm_to_dd, transform/rename_uid, groupbyattrs, k8sattributes, cumulativetodelta, transform/sum_to_gauge]
+        processors: [filter/ksm, resourcedetection, transform/ksm_to_dd, transform/rename_uid, groupbyattrs, k8s_attributes, cumulativetodelta, transform/sum_to_gauge]
         exporters: [datadog/exporter]

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -147,7 +147,7 @@ config:
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
     # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.152.0/processor/resourcedetectionprocessor#cluster-name
     resourcedetection:
-      detectors: ["k8snode", "system", "ec2", "eks", "aks", "gcp", "kubeadm"]
+      detectors: ["k8snode", "ec2", "eks", "aks", "gcp", "kubeadm"]
       override: false
       # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
       # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -17,8 +17,6 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secret
         key: api-key
-  - name: CLUSTER_NAME
-    valueFrom: 
 
 config:
   receivers:
@@ -57,14 +55,7 @@ config:
         - k8s.pod.network.io
         - k8s.pod.network.errors
 
-    resource:
-      attributes:
-        # Globally set k8s cluster name on all resources
-        - key: k8s.cluster.name
-          value: <YOUR K8S CLUSTER NAME HERE>
-          action: "insert"
-
-    k8sattributes:
+    k8s_attributes:
       auth_type: "serviceAccount"
       extract:
         otel_annotations: true
@@ -77,19 +68,65 @@ config:
           - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
-          - service.namespace
+          - k8s.cronjob.name
+          - k8s.job.name
           - k8s.container.name
+          - service.namespace
           - service.name
           - service.version
           - service.instance.id
           - container.id
-      passthrough: false
-
-    # the order of resource detection is important as it will influence how attributes
-    # like "host" are sourced
+          - container.image.name
+          - container.image.tag
+      pod_association:
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        - sources:
+            - from: connection
+    
+    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
+    # Adjust the k8s.cluster.name settings below for your cloud provider.
+    # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
+    # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.152.0/processor/resourcedetectionprocessor#cluster-name
     resourcedetection:
-      detectors: ["k8snode", "system", "ec2", "eks", "kubeadm"]
+      detectors: ["k8snode", "system", "ec2", "eks", "aks", "gcp", "kubeadm"]
       override: false
+      # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
+      # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.
+      # If running on a kubeadm cluster, set k8s.cluster.name.enabled to true.
+      kubeadm:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: false
+      eks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+      aks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+      gcp:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+
+    # Manually inject the cluster name if your cloud provider is not supported by the resourcedetection processor.
+    # resource/add-cluster-name:
+    #   attributes:
+    #     - key: k8s.cluster.name
+    #       value: <YOUR_CLUSTER_NAME>
+    #       action: upsert
+  
     
     memory_limiter:
       check_interval: 5s
@@ -113,5 +150,5 @@ config:
 
       metrics:
         receivers: [datadog/connector, otlp]
-        processors: [resourcedetection, resource, k8sattributes, cumulativetodelta, deltatorate]
+        processors: [resourcedetection, k8s_attributes, cumulativetodelta, deltatorate]
         exporters: [datadog/exporter]

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -98,7 +98,7 @@ config:
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
     # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.152.0/processor/resourcedetectionprocessor#cluster-name
     resourcedetection:
-      detectors: ["k8snode", "system", "ec2", "eks", "aks", "gcp", "kubeadm"]
+      detectors: ["k8snode", "ec2", "eks", "aks", "gcp", "kubeadm"]
       override: false
       # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
       # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.


### PR DESCRIPTION
 ### Description:
  
Previously, users had to hardcode their Kubernetes cluster name in two places before the collectors would work correctly. 
This PR removes that manual step by switching to automatic cluster name detection.

### What changed:

  - Automatic cluster name detection — The collectors now detect `k8s.cluster.name `automatically on EKS, AKS, and GKE.  A commented-out fallback is provided for unsupported environments.
  - More Kubernetes metadata enriched — Both collectors now extract additional attributes: k8s.cronjob.name, k8s.job.name, container.image.name, container.image.tag, and service.namespace.
  - Upgraded to k8s_attributes — Migrated from the deprecated k8sattributes processor to the current k8s_attributes. https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339
  - Simplified install instructions — The quickstart no longer requires exporting a cluster name environment variable before running helm  install.
