### PR TITLE
Improve Kubernetes collector configurations

### DIFF
--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -6,8 +6,6 @@ mode: deployment
 presets:
   clusterMetrics:
     enabled: true
-  kubernetesAttributes:
-    enabled: true
 
 extraEnvs:
   - name: DD_API_KEY
@@ -15,17 +13,18 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secret
         key: api-key
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
 
 config:
   receivers:
-    k8s_cluster:
-      auth_type: serviceAccount
-    
     # Prometheus receiver is used to scrape kube state metrics
     prometheus:
       config:
         scrape_configs:
-          - job_name: 'kube-state-metrics'
+          - job_name: "kube-state-metrics"
             metrics_path: /metrics
             scheme: http
             static_configs:
@@ -33,7 +32,7 @@ config:
                   - kube-state-metrics.default.svc:8080
             metric_relabel_configs:
               - source_labels: [__name__]
-                regex: 'kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type'
+                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                 action: keep
 
   processors:
@@ -46,14 +45,14 @@ config:
           statements:
             - set(attributes["k8s.pod.uid"], attributes["uid"])
             - delete_key(attributes, "uid")
-        # We have to delete these from the resource because they were incorrectly 
+        # We have to delete these from the resource because they were incorrectly
         # set by the prometheus receiver, k8s_attributes will repopulate them but
         # cannot overwrite them.
         - context: resource
           statements:
             - delete_key(attributes, "service.name")
             - delete_key(attributes, "service.instance.id")
-    
+
     # Grouping by k8s.pod.uid (a globally unique ID) correctly associates the
     # kube-state-metrics pod metrics with their respective OTel resources.
     groupbyattrs:
@@ -97,7 +96,7 @@ config:
             # service
             - set(attributes["kube_service"], attributes["service"])
             - delete_key(attributes, "service")
-    
+
     # k8s_attributesprocessor is used to enrich metrics with additional metadata, namely, service.
     k8s_attributes:
       auth_type: "serviceAccount"
@@ -129,7 +128,7 @@ config:
         - sources:
             - from: resource_attribute
               name: k8s.pod.uid
-    
+
     transform/sum_to_gauge:
       metric_statements:
         - convert_sum_to_gauge() where metric.name == "k8s.service.count"
@@ -141,7 +140,7 @@ config:
       metrics:
         metric:
           - metric.name == "kube_service_spec_type"
-    
+
     # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
@@ -175,9 +174,9 @@ config:
     #     - key: k8s.cluster.name
     #       value: <YOUR_CLUSTER_NAME>
     #       action: upsert
-  
+
   connectors:
-    # The count connector helps us generate three custom metrics by counting the number 
+    # The count connector helps us generate three custom metrics by counting the number
     # of metric series. It generates the following metrics:
     # 1. k8s.service.count
     # 2. k8s.node.count
@@ -207,14 +206,24 @@ config:
     datadog/exporter:
       api:
         key: ${env:DD_API_KEY}
-  
+
   service:
     pipelines:
       metrics/count:
         receivers: [prometheus]
         exporters: [count]
-        
+
       metrics:
         receivers: [otlp, prometheus, count]
-        processors: [filter/ksm, resourcedetection, transform/ksm_to_dd, transform/rename_uid, groupbyattrs, k8s_attributes, cumulativetodelta, transform/sum_to_gauge]
+        processors:
+          [
+            filter/ksm,
+            resourcedetection,
+            transform/ksm_to_dd,
+            transform/rename_uid,
+            groupbyattrs,
+            k8s_attributes,
+            cumulativetodelta,
+            transform/sum_to_gauge,
+          ]
         exporters: [datadog/exporter]

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -1,11 +1,9 @@
 enabled: true
 mode: daemonset
 
-# Enabling presets automatically configures the necessary service accounts 
+# Enabling presets automatically configures the necessary service accounts
 # and sane defaults
 presets:
-  kubernetesAttributes:
-    enabled: true
   hostMetrics:
     enabled: true
   kubeletMetrics:
@@ -18,20 +16,59 @@ extraEnvs:
         name: datadog-secret
         key: api-key
 
+service:
+  enabled: true
+
+clusterRole:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["pods", "namespaces", "nodes", "nodes/stats"]
+      verbs: ["get", "watch", "list"]
+    - apiGroups: ["apps"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+
 config:
   receivers:
     hostmetrics:
+      root_path: /hostfs # Necessary inside containers, corresponds to / on host
+      collection_interval: 10s
       scrapers:
         cpu:
           metrics:
+            system.cpu.utilization:
+              enabled: true
+            system.cpu.physical.count:
+              enabled: true
             system.cpu.logical.count:
-              enabled: true # this is disabled by default, but we need to map system.cpu.num_cores
+              enabled: true
+            system.cpu.frequency:
+              enabled: true
+        memory:
+          metrics:
+            system.memory.limit:
+              enabled: true
+        paging:
+          metrics:
+            system.paging.utilization:
+              enabled: true
+            system.paging.usage:
+              enabled: true
+        disk: {}
+        filesystem:
+          metrics:
+            system.filesystem.utilization:
+              enabled: true
+        load: {}
+        network: {}
+        processes: {}
 
     kubeletstats:
       collection_interval: 15s
-      auth_type: 'serviceAccount'
-      endpoint: '${env:K8S_NODE_NAME}:10250'
-      node: '${env:K8S_NODE_NAME}'
+      auth_type: "serviceAccount"
+      endpoint: "${env:K8S_NODE_NAME}:10250"
+      node: "${env:K8S_NODE_NAME}"
       insecure_skip_verify: true
       metric_groups:
         - node
@@ -47,7 +84,7 @@ config:
           enabled: true
         k8s.pod.memory.node.utilization:
           enabled: true
-          
+
   processors:
     cumulativetodelta: {}
     deltatorate:
@@ -92,7 +129,7 @@ config:
               name: k8s.namespace.name
         - sources:
             - from: connection
-    
+
     # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
@@ -126,29 +163,49 @@ config:
     #     - key: k8s.cluster.name
     #       value: <YOUR_CLUSTER_NAME>
     #       action: upsert
-  
-    
+
     memory_limiter:
       check_interval: 5s
       limit_percentage: 75
       spike_limit_percentage: 15
 
   connectors:
-    datadog/connector:
-      traces:
-  
+    datadog/connector: {}
+
   exporters:
     datadog/exporter:
       api:
         key: ${env:DD_API_KEY}
 
+  extensions:
+    datadog:
+      api:
+        key: ${env:DD_API_KEY}
+      deployment_type: daemonset
+
   service:
+    extensions:
+      - health_check
+      - datadog
+
     pipelines:
-      traces: 
+      logs:
         receivers: [otlp]
+        processors: [resourcedetection, k8s_attributes]
+        exporters: [datadog/exporter]
+
+      traces:
+        receivers: [otlp]
+        processors: [resourcedetection, k8s_attributes]
         exporters: [datadog/connector]
+
+      traces/sampling:
+        receivers: [datadog/connector]
+        # Perform any sampling here
+        exporters: [datadog/exporter]
 
       metrics:
         receivers: [datadog/connector, otlp]
-        processors: [resourcedetection, k8s_attributes, cumulativetodelta, deltatorate]
+        processors:
+          [resourcedetection, k8s_attributes, cumulativetodelta, deltatorate]
         exporters: [datadog/exporter]


### PR DESCRIPTION
### What does this PR do?

#### Both collectors
  - Format YAML
  - Removed `kubernetesAttributes` preset — it was injecting a duplicate `k8sattributes` processor into the pipeline alongside our custom `k8s_attributes`, causing metrics to be enriched twice.  https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/templates/_config.tpl#L404

#### Daemonset collector
  - Expanded hostmetrics scraper coverage
  - Added logs and traces/sampling pipelines for full telemetry coverage
  - Added ClusterRole rules for pod/node/replicasets/namespaces access required by `k8s_attributes`
  - Added datadog extension

#### Cluster collector
  - Added `K8S_NODE_NAME` env var required by the `k8snode` resource detector
