### PR TITLE
Small fix ups for dual shipping config

### DIFF
--- a/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
@@ -135,6 +135,8 @@ extensions:
     {{include "datadog-extension" . | indent 4}}
   {{- if .DualShip}}
   datadog/dual_ship:
+    http:
+      endpoint: "localhost:9876" # Avoid port collision
     {{- set . "EnvSuffix" "_DUAL_SHIP"}}
     {{include "datadog-extension" . | indent 4}}
   {{- end}}

--- a/configurations/opentelemetry-collector/testing/README.md
+++ b/configurations/opentelemetry-collector/testing/README.md
@@ -26,8 +26,8 @@ The current testing configuration has experimental flags enabled to dual ship th
 Example:
 ```sh
 # Update DD_SITE, DD_SITE_DUAL_SHIP, and deployment.environment.name in ./testing/otel-demo.yaml
-kubectl create secret generic datadog-secrets --from-literal=api-key='insertyourapikey' \
-  --from-literal=api-key-dual-ship='insertyourapikey'
+kubectl create secret generic datadog-secrets --from-literal=api-key='insertyourapikey'
+kubectl create secret generic datadog-secrets-dual-ship --from-literal=api-key='insertyourapikey'
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install otel-demo open-telemetry/opentelemetry-demo --values ./testing/otel-demo.yaml
 ```

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -404,6 +404,8 @@ opentelemetry-collector:
           key: ${env:DD_API_KEY_DUAL_SHIP}
         deployment_type: daemonset
       datadog/dual_ship:
+        http:
+          endpoint: "localhost:9876" # Avoid port collision
         api:
           site: ${env:DD_SITE_DUAL_SHIP}
           key: ${env:DD_API_KEY_DUAL_SHIP}

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -402,6 +402,8 @@ opentelemetry-collector:
           key: ${env:DD_API_KEY_DUAL_SHIP}
         deployment_type: daemonset
       datadog/dual_ship:
+        http:
+          endpoint: "localhost:9876" # Avoid port collision
         api:
           site: ${env:DD_SITE_DUAL_SHIP}
           key: ${env:DD_API_KEY_DUAL_SHIP}


### PR DESCRIPTION
### What does this PR do?

By default the two Datadog extensions tried to listen on the same port, preventing startup. I modified the second extension to listen on port 9876 instead of 9875.

I also fixed the documentation in `testing/README.md` to match the actual config regarding how to set the API key for dual shipping.