### PR TITLE
[CONTINT-5316] Add k8s.namespace.count in cluster collector conf

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -29,7 +29,7 @@ Many of the metrics collected for the Kubernetes integration report on the _over
 | processor   | [transform][6]          | Modifies, adds, and deletes resource/datapoint attributes |
 | processor   | [groupbyattrs][7]       | Associates kube-state-metrics Pod datapoints with the correct OTel resource by Pod UID |
 | processor   | [k8s_attributes][8]     | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
-| connector   | [count][9]              | Counts Kubernetes metrics to generate `k8s.node.count`, `k8s.job.count`, `k8s.service.count`, `k8s.deployment.count`, and `k8s.pod.count` |
+| connector   | [count][9]              | Counts Kubernetes metrics to generate `k8s.node.count`, `k8s.job.count`, `k8s.service.count`, `k8s.deployment.count`, `k8s.pod.count`, and `k8s.namespace.count` |
 | exporter    | [datadog][10]           | Ships telemetry to Datadog |
 
 ### Node Collector

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -1,4 +1,5 @@
 enabled: true
+
 mode: deployment
 
 # Enabling presets automatically configures the necessary service accounts
@@ -42,7 +43,7 @@ config:
                   - kube-state-metrics.default.svc:8080
             metric_relabel_configs:
               - source_labels: [__name__]
-                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_.*|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
+                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                 action: keep
 
   processors:

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -42,7 +42,7 @@ config:
                   - kube-state-metrics.default.svc:8080
             metric_relabel_configs:
               - source_labels: [__name__]
-                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
+                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_.*|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                 action: keep
 
   processors:
@@ -146,12 +146,14 @@ config:
         - convert_sum_to_gauge() where metric.name == "k8s.job.count"
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
 
-    # Drop metric after count connector has used it
+    # Drop metrics after count connector has used them
     filter/ksm:
       metrics:
         metric:
           - metric.name == "kube_service_spec_type"
+          - metric.name == "kube_namespace_created"
 
     # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
@@ -188,13 +190,14 @@ config:
     #       action: upsert
 
   connectors:
-    # The count connector helps us generate three custom metrics by counting the number
+    # The count connector helps us generate six custom metrics by counting the number
     # of metric series. It generates the following metrics:
     # 1. k8s.service.count
     # 2. k8s.node.count
     # 3. k8s.job.count
     # 4. k8s.deployment.count
     # 5. k8s.pod.count
+    # 6. k8s.namespace.count
     count:
       datapoints:
         k8s.service.count:
@@ -229,6 +232,10 @@ config:
               default_value: unspecified_namespace
           conditions:
             - metric.name == "kube_pod_info"
+
+        k8s.namespace.count:
+          conditions:
+            - metric.name == "kube_namespace_created"
 
   exporters:
     datadog/exporter:


### PR DESCRIPTION
### What does this PR do?

This PR adds `k8s.namespace.count` in the cluster collector config, similar to `k8s.job.count`. We also need to add `kube_namespace_.*` to the regex to do this. 

Verification was done on a local kind cluster, results can be seen on this timeseries: https://dd.datad0g.com/s/yB5yjZ/jzm-twa-ekz

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5316