### PR TITLE
Add k8s.deployment.count and k8s.pod.count to cluster collector

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -29,7 +29,7 @@ Many of the metrics collected for the Kubernetes integration report on the _over
 | processor   | [transform][6]          | Modifies, adds, and deletes resource/datapoint attributes |
 | processor   | [groupbyattrs][7]       | Associates kube-state-metrics Pod datapoints with the correct OTel resource by Pod UID |
 | processor   | [k8s_attributes][8]     | Enriches Kubernetes metrics with additional metadata (ex: annotations/labels) |
-| connector   | [count][9]              | Counts Kubernetes metrics to generate `k8s.node.count`, `k8s.job.count`, and `k8s.service.count` |
+| connector   | [count][9]              | Counts Kubernetes metrics to generate `k8s.node.count`, `k8s.job.count`, `k8s.service.count`, `k8s.deployment.count`, and `k8s.pod.count` |
 | exporter    | [datadog][10]           | Ships telemetry to Datadog |
 
 ### Node Collector

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -144,6 +144,8 @@ config:
         - convert_sum_to_gauge() where metric.name == "k8s.service.count"
         - convert_sum_to_gauge() where metric.name == "k8s.node.count"
         - convert_sum_to_gauge() where metric.name == "k8s.job.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
 
     # Drop metric after count connector has used it
     filter/ksm:
@@ -191,6 +193,8 @@ config:
     # 1. k8s.service.count
     # 2. k8s.node.count
     # 3. k8s.job.count
+    # 4. k8s.deployment.count
+    # 5. k8s.pod.count
     count:
       datapoints:
         k8s.service.count:
@@ -211,6 +215,20 @@ config:
         k8s.job.count:
           conditions:
             - metric.name == "kube_job_owner"
+
+        k8s.deployment.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
+          conditions:
+            - metric.name == "kube_deployment_created"
+
+        k8s.pod.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
+          conditions:
+            - metric.name == "kube_pod_info"
 
   exporters:
     datadog/exporter:


### PR DESCRIPTION
### What does this PR do?

This PR adds `k8s.deployment.count` and `k8s.pod.count` in the cluster collector config, similar to `k8s.job.count`. 

Verification was done on a local kind cluster, results can be seen on this [timeseries](https://dd.datad0g.com/metric/explorer?fromUser=true&graph_layout=stacked&start=1780599159580&end=1780599459580&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyADWeABGOiKImmkInnAAdALyaDhY6iIIHZn4g8C1DU6ZaHgaCDpOkeo1olAAtNWrPCB8oEs5ILFYAEyJyW1pGdnK+YXFh6U0uRVV1QAcGl1wPX0DQyN4MYTOBTGZzBb7FYidabaHbXYRKIHI4AZjOKUueCyB1uECKiSO5UqNQ+HQcUGGowQ43qIOms3m2kWSKhMK2OwoeyRMUeABZ0Rd0ljrrlcfiSjoniAXjVadomvMNK12mScBSAUDaaCGRCWbC2XCdgBdKiudx4TChcJm1QWjA8yUJBE2u0OuKnZ1uW2YN1YNGe80+3JHfk8E3SuRoHKgeQYKMIebKc4YKA4GBkABsiTQohBckU5RwOag2dzTnoTGUIi9cY5SQg9kwWCc+YOOaaxp4fGlPXEAGEpMIYCgRBa0DwgA)
<img width="1784" height="520" alt="image" src="https://github.com/user-attachments/assets/c241c9d8-7155-477e-9e9d-31979798ffea" />


### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5315
