### PR TITLE
remove k8s.*.node.utilization from otel k8s config

### DIFF
--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -75,15 +75,6 @@ config:
         - pod
         - container
         - volume
-      metrics:
-        k8s.container.cpu.node.utilization:
-          enabled: true
-        k8s.pod.cpu.node.utilization:
-          enabled: true
-        k8s.container.memory.node.utilization:
-          enabled: true
-        k8s.pod.memory.node.utilization:
-          enabled: true
 
   processors:
     cumulativetodelta: {}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

These changes were introduced in https://github.com/DataDog/opentelemetry-examples/commit/6c33b59ab8b726a118c589ad5b1acab1339b09a5.

However, we never configured k8s_api_config: { auth_type: serviceAccount }, which is required to collect the k8s.*.node.utilization metrics. This is also confirmed by the receiver documentation:
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver#collect-k8scontainerpodcpumemorynodeutilization-as-ratio-of-total-nodes-capacity

Since we don't use these metrics in either Kubernetes Explorer or the Kubernetes out-of-the-box dashboard, I think we can safely remove them.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
