### PR TITLE
CAP-3718 update resourcedetection for otel config

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -124,7 +124,7 @@ spec:
 <blockquote> NOTE: If you are incorporating the configuration files found in [/configuration](/documentation/kubernetes/configuration/) into your existing OpenTelemetry collector deployment, please be aware that they are specifically written for
 
 * [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) helm chart >= `0.156.2`
-* OTel image `otel/opentelemetry-collector-contrib` >= `0.153.0`
+* OTel image `otel/opentelemetry-collector-contrib` >= `0.154.0`
 
 </blockquote>
 
@@ -159,12 +159,12 @@ helm repo update
 # Install the Daemonset Collector
 helm install otel-daemon-collector open-telemetry/opentelemetry-collector -f configuration/daemonset-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.153.0
+  --set image.tag=0.154.0
 
 # Install the Cluster Collector
 helm install otel-cluster-collector open-telemetry/opentelemetry-collector -f configuration/cluster-collector.yaml \
   --set image.repository=otel/opentelemetry-collector-contrib \
-  --set image.tag=0.153.0
+  --set image.tag=0.154.0
 ```
 
 > [!NOTE]

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -151,20 +151,13 @@ config:
         metric:
           - metric.name == "kube_service_spec_type"
 
-    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
+    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (k8s_api).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
     # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.153.0/processor/resourcedetectionprocessor#cluster-name
     resourcedetection:
-      detectors: ["k8snode", "ec2", "eks", "aks", "gcp", "kubeadm"]
+      detectors: ["k8s_api", "ec2", "eks", "aks", "gcp"]
       override: false
-      # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
-      # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.
-      # If running on a kubeadm cluster, set k8s.cluster.name.enabled to true.
-      kubeadm:
-        resource_attributes:
-          k8s.cluster.name:
-            enabled: false
       eks:
         resource_attributes:
           k8s.cluster.name:

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -121,20 +121,13 @@ config:
         - sources:
             - from: connection
 
-    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (kubeadm).
+    # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (k8s_api).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
     # If your cloud provider is not supported, use the optional resource/add-cluster-name processor below instead.
     # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.153.0/processor/resourcedetectionprocessor#cluster-name
     resourcedetection:
-      detectors: ["k8snode", "ec2", "eks", "aks", "gcp", "kubeadm"]
+      detectors: ["k8s_api", "ec2", "eks", "aks", "gcp"]
       override: false
-      # kubeadm adds k8s.cluster.uid; k8s.cluster.name is disabled to prevent the detector
-      # from searching for the kubeadm-config ConfigMap on non-kubeadm clusters.
-      # If running on a kubeadm cluster, set k8s.cluster.name.enabled to true.
-      kubeadm:
-        resource_attributes:
-          k8s.cluster.name:
-            enabled: false
       eks:
         resource_attributes:
           k8s.cluster.name:


### PR DESCRIPTION
### What does this PR do?

In OTel Collector 0.154.0, the resource detection processor renamed the `k8snode` to `k8s_api` detector. Additionally, the `k8s_api` detector now supports the `k8s.cluster.uid` attribute, which means we can remove the `kubeadm` detector.

See the release notes: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0
