### PR TITLE
OTEL-3067 Use spanmetrics glob patterns to simplify recommended configuration

### DIFF
--- a/configurations/opentelemetry-collector/README.md
+++ b/configurations/opentelemetry-collector/README.md
@@ -31,7 +31,7 @@ These files are the raw YAML configuration we recommend passing to a Collector u
 
 Example:
 ```sh
-DD_SITE=datadoghq.com DD_API_KEY='insertyourapikey' ./otelcol-contrib --config ./agent.yaml --feature-gates connector.spanmetrics.includeCollectorInstanceID
+DD_SITE=datadoghq.com DD_API_KEY='insertyourapikey' ./otelcol-contrib --config ./agent.yaml
 ```
 
 ### Agent deployment pattern

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -158,21 +158,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -151,13 +151,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Uncontainerized Agent in an Azure VM environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -159,9 +159,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -131,13 +131,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -139,9 +139,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -138,21 +138,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Containerized Agent in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -158,21 +158,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -151,13 +151,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Uncontainerized Agent in an EC2 environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -159,9 +159,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Uncontainerized Agent in a GCE environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -158,21 +158,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -151,13 +151,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -159,9 +159,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -158,21 +158,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Uncontainerized Agent in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -151,13 +151,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -159,9 +159,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -218,9 +218,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Kubernetes Daemonset in an EKS environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -217,21 +217,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -210,13 +210,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -179,21 +179,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -180,9 +180,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Kubernetes Daemonset in a GKE Autopilot environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -172,13 +172,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -214,9 +214,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Kubernetes Daemonset in a GKE environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -213,21 +213,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -206,13 +206,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -214,9 +214,9 @@ connectors:
       # - name: cloud.region
       # - name: cloud.availability_zone
       ## Comment out all aws.ecs tags above if you uncomment this
-      # - name: aws.ecs.**
+      # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this
-      # - name: k8s.*.name
+      # - glob: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -213,21 +213,10 @@ connectors:
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
-      # - name: aws.ecs.task.family
-      # # - name: aws.ecs.task.arn
-      # - name: aws.ecs.cluster.arn
-      # - name: aws.ecs.task.revision
-      # - name: aws.ecs.container.arn
-      # - name: k8s.container.name
-      # # - name: k8s.cluster.name
-      # - name: k8s.deployment.name
-      # - name: k8s.replicaset.name
-      # - name: k8s.statefulset.name
-      # - name: k8s.daemonset.name
-      # - name: k8s.job.name
-      # - name: k8s.cronjob.name
-      # - name: k8s.namespace.name
-      # - name: k8s.pod.name
+      ## Comment out all aws.ecs tags above if you uncomment this
+      # - name: aws.ecs.**
+      ## Comment out all k8s.*.name tags above if you uncomment this
+      # - name: k8s.*.name
   # Separate trace processing from sampling so span metrics are computed on all traces
   forward/traces_sample: {}
 

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -206,13 +206,11 @@ connectors:
     
       ## Optional container tags
       ## May be used as additional primary tags or in service remapping rules
-      # - name: container.name
-      # - name: container.image.name
-      # - name: container.image.tag
-      # - name: container.runtime
       # # - name: cloud.provider
       # - name: cloud.region
       # - name: cloud.availability_zone
+      ## Comment out all container tags above if you uncomment this
+      # - glob: container.**
       ## Comment out all aws.ecs tags above if you uncomment this
       # - glob: aws.ecs.**
       ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -1,6 +1,6 @@
 # Recommended OpenTelemetry Collector configuration
 # Setup: Kubernetes Daemonset in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/generator/configs.go
+++ b/configurations/opentelemetry-collector/generator/configs.go
@@ -1,6 +1,6 @@
 package main
 
-var otelcolVersion = "0.152.0"
+var otelcolVersion = "0.154.0"
 
 var hostEnvs = []string{"", "ec2", "gce", "azure"}
 

--- a/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
@@ -76,7 +76,7 @@ dimensions:
   # - name: cloud.region
   # - name: cloud.availability_zone
   ## Comment out all aws.ecs tags above if you uncomment this
-  # - name: aws.ecs.**
+  # - glob: aws.ecs.**
   ## Comment out all k8s.*.name tags above if you uncomment this
-  # - name: k8s.*.name
+  # - glob: k8s.*.name
   {{- /* OTEL-2937: Add datadog.container.tag.* */}}

--- a/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
@@ -68,13 +68,11 @@ dimensions:
 
   ## Optional container tags
   ## May be used as additional primary tags or in service remapping rules
-  # - name: container.name
-  # - name: container.image.name
-  # - name: container.image.tag
-  # - name: container.runtime
   # # - name: cloud.provider
   # - name: cloud.region
   # - name: cloud.availability_zone
+  ## Comment out all container tags above if you uncomment this
+  # - glob: container.**
   ## Comment out all aws.ecs tags above if you uncomment this
   # - glob: aws.ecs.**
   ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/span-metrics-connector.tmpl
@@ -75,19 +75,8 @@ dimensions:
   # # - name: cloud.provider
   # - name: cloud.region
   # - name: cloud.availability_zone
-  # - name: aws.ecs.task.family
-  # # - name: aws.ecs.task.arn
-  # - name: aws.ecs.cluster.arn
-  # - name: aws.ecs.task.revision
-  # - name: aws.ecs.container.arn
-  # - name: k8s.container.name
-  # # - name: k8s.cluster.name
-  # - name: k8s.deployment.name
-  # - name: k8s.replicaset.name
-  # - name: k8s.statefulset.name
-  # - name: k8s.daemonset.name
-  # - name: k8s.job.name
-  # - name: k8s.cronjob.name
-  # - name: k8s.namespace.name
-  # - name: k8s.pod.name
+  ## Comment out all aws.ecs tags above if you uncomment this
+  # - name: aws.ecs.**
+  ## Comment out all k8s.*.name tags above if you uncomment this
+  # - name: k8s.*.name
   {{- /* OTEL-2937: Add datadog.container.tag.* */}}

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -269,21 +269,10 @@ alternateConfig:
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
-        # - name: aws.ecs.task.family
-        # # - name: aws.ecs.task.arn
-        # - name: aws.ecs.cluster.arn
-        # - name: aws.ecs.task.revision
-        # - name: aws.ecs.container.arn
-        # - name: k8s.container.name
-        # # - name: k8s.cluster.name
-        # - name: k8s.deployment.name
-        # - name: k8s.replicaset.name
-        # - name: k8s.statefulset.name
-        # - name: k8s.daemonset.name
-        # - name: k8s.job.name
-        # - name: k8s.cronjob.name
-        # - name: k8s.namespace.name
-        # - name: k8s.pod.name
+        ## Comment out all aws.ecs tags above if you uncomment this
+        # - name: aws.ecs.**
+        ## Comment out all k8s.*.name tags above if you uncomment this
+        # - name: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -270,9 +270,9 @@ alternateConfig:
         # - name: cloud.region
         # - name: cloud.availability_zone
         ## Comment out all aws.ecs tags above if you uncomment this
-        # - name: aws.ecs.**
+        # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this
-        # - name: k8s.*.name
+        # - glob: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -262,13 +262,11 @@ alternateConfig:
       
         ## Optional container tags
         ## May be used as additional primary tags or in service remapping rules
-        # - name: container.name
-        # - name: container.image.name
-        # - name: container.image.tag
-        # - name: container.runtime
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
+        ## Comment out all container tags above if you uncomment this
+        # - glob: container.**
         ## Comment out all aws.ecs tags above if you uncomment this
         # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -19,7 +19,7 @@ extraEnvs:
 mode: daemonset
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
   extraArgs: []

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -221,21 +221,10 @@ alternateConfig:
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
-        # - name: aws.ecs.task.family
-        # # - name: aws.ecs.task.arn
-        # - name: aws.ecs.cluster.arn
-        # - name: aws.ecs.task.revision
-        # - name: aws.ecs.container.arn
-        # - name: k8s.container.name
-        # # - name: k8s.cluster.name
-        # - name: k8s.deployment.name
-        # - name: k8s.replicaset.name
-        # - name: k8s.statefulset.name
-        # - name: k8s.daemonset.name
-        # - name: k8s.job.name
-        # - name: k8s.cronjob.name
-        # - name: k8s.namespace.name
-        # - name: k8s.pod.name
+        ## Comment out all aws.ecs tags above if you uncomment this
+        # - name: aws.ecs.**
+        ## Comment out all k8s.*.name tags above if you uncomment this
+        # - name: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -222,9 +222,9 @@ alternateConfig:
         # - name: cloud.region
         # - name: cloud.availability_zone
         ## Comment out all aws.ecs tags above if you uncomment this
-        # - name: aws.ecs.**
+        # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this
-        # - name: k8s.*.name
+        # - glob: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -214,13 +214,11 @@ alternateConfig:
       
         ## Optional container tags
         ## May be used as additional primary tags or in service remapping rules
-        # - name: container.name
-        # - name: container.image.name
-        # - name: container.image.tag
-        # - name: container.runtime
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
+        ## Comment out all container tags above if you uncomment this
+        # - glob: container.**
         ## Comment out all aws.ecs tags above if you uncomment this
         # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -19,7 +19,7 @@ extraEnvs:
 mode: daemonset
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
   extraArgs: []

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -258,13 +258,11 @@ alternateConfig:
       
         ## Optional container tags
         ## May be used as additional primary tags or in service remapping rules
-        # - name: container.name
-        # - name: container.image.name
-        # - name: container.image.tag
-        # - name: container.runtime
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
+        ## Comment out all container tags above if you uncomment this
+        # - glob: container.**
         ## Comment out all aws.ecs tags above if you uncomment this
         # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -265,21 +265,10 @@ alternateConfig:
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
-        # - name: aws.ecs.task.family
-        # # - name: aws.ecs.task.arn
-        # - name: aws.ecs.cluster.arn
-        # - name: aws.ecs.task.revision
-        # - name: aws.ecs.container.arn
-        # - name: k8s.container.name
-        # # - name: k8s.cluster.name
-        # - name: k8s.deployment.name
-        # - name: k8s.replicaset.name
-        # - name: k8s.statefulset.name
-        # - name: k8s.daemonset.name
-        # - name: k8s.job.name
-        # - name: k8s.cronjob.name
-        # - name: k8s.namespace.name
-        # - name: k8s.pod.name
+        ## Comment out all aws.ecs tags above if you uncomment this
+        # - name: aws.ecs.**
+        ## Comment out all k8s.*.name tags above if you uncomment this
+        # - name: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -266,9 +266,9 @@ alternateConfig:
         # - name: cloud.region
         # - name: cloud.availability_zone
         ## Comment out all aws.ecs tags above if you uncomment this
-        # - name: aws.ecs.**
+        # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this
-        # - name: k8s.*.name
+        # - glob: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -19,7 +19,7 @@ extraEnvs:
 mode: daemonset
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
   extraArgs: []

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -268,9 +268,9 @@ alternateConfig:
         # - name: cloud.region
         # - name: cloud.availability_zone
         ## Comment out all aws.ecs tags above if you uncomment this
-        # - name: aws.ecs.**
+        # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this
-        # - name: k8s.*.name
+        # - glob: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -22,7 +22,7 @@ extraEnvs:
 mode: daemonset
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
   extraArgs: []

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -267,21 +267,10 @@ alternateConfig:
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
-        # - name: aws.ecs.task.family
-        # # - name: aws.ecs.task.arn
-        # - name: aws.ecs.cluster.arn
-        # - name: aws.ecs.task.revision
-        # - name: aws.ecs.container.arn
-        # - name: k8s.container.name
-        # # - name: k8s.cluster.name
-        # - name: k8s.deployment.name
-        # - name: k8s.replicaset.name
-        # - name: k8s.statefulset.name
-        # - name: k8s.daemonset.name
-        # - name: k8s.job.name
-        # - name: k8s.cronjob.name
-        # - name: k8s.namespace.name
-        # - name: k8s.pod.name
+        ## Comment out all aws.ecs tags above if you uncomment this
+        # - name: aws.ecs.**
+        ## Comment out all k8s.*.name tags above if you uncomment this
+        # - name: k8s.*.name
     # Separate trace processing from sampling so span metrics are computed on all traces
     forward/traces_sample: {}
   

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -260,13 +260,11 @@ alternateConfig:
       
         ## Optional container tags
         ## May be used as additional primary tags or in service remapping rules
-        # - name: container.name
-        # - name: container.image.name
-        # - name: container.image.tag
-        # - name: container.runtime
         # # - name: cloud.provider
         # - name: cloud.region
         # - name: cloud.availability_zone
+        ## Comment out all container tags above if you uncomment this
+        # - glob: container.**
         ## Comment out all aws.ecs tags above if you uncomment this
         # - glob: aws.ecs.**
         ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -16,7 +16,7 @@ extraEnvs:
 mode: deployment
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
 

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
@@ -16,7 +16,7 @@ extraEnvs:
 mode: deployment
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
 

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -19,7 +19,7 @@ extraEnvs:
 mode: deployment
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
 

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -1,7 +1,7 @@
 # Recommended OpenTelemetry Collector configuration (Deployment mode)
 # Paired with daemonset-eks.yaml to collect cluster level resources to support K8s Explorer
 # Setup: Kubernetes per-cluster Deployment (k8s_objects) in an EKS environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
@@ -1,7 +1,7 @@
 # Recommended OpenTelemetry Collector configuration (Deployment mode)
 # Paired with daemonset-gke.yaml to collect cluster level resources to support K8s Explorer
 # Setup: Kubernetes per-cluster Deployment (k8s_objects) in a GKE environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -1,7 +1,7 @@
 # Recommended OpenTelemetry Collector configuration (Deployment mode)
 # Paired with daemonset.yaml to collect cluster level resources to support K8s Explorer
 # Setup: Kubernetes per-cluster Deployment (k8s_objects) in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/testing/agent-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/agent-datadog.yaml
@@ -1,7 +1,7 @@
 # FOR INTERNAL TESTING PURPOSES ONLY
 # Recommended OpenTelemetry Collector configuration
 # Setup: Uncontainerized Agent in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
@@ -1,7 +1,7 @@
 # FOR INTERNAL TESTING PURPOSES ONLY
 # Recommended OpenTelemetry Collector configuration
 # Setup: Kubernetes Daemonset in a non-cloud environment
-# Collector Contrib version: v0.152.0
+# Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -17,7 +17,7 @@ extraEnvs:
 mode: deployment
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
 

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -20,7 +20,7 @@ extraEnvs:
 mode: deployment
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.152.0
+  tag: 0.154.0
 command:
   name: "otelcol-contrib"
 

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
@@ -65,7 +65,7 @@ opentelemetry-collector:
   mode: daemonset
   image:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.152.0
+    tag: 0.154.0
   command:
     name: "otelcol-contrib"
     extraArgs: []

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
@@ -68,7 +68,7 @@ opentelemetry-collector:
   mode: daemonset
   image:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.152.0
+    tag: 0.154.0
   command:
     name: "otelcol-contrib"
     extraArgs: []

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -68,7 +68,7 @@ opentelemetry-collector:
   mode: daemonset
   image:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.152.0
+    tag: 0.154.0
   command:
     name: "otelcol-contrib"
     extraArgs: []

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -329,9 +329,9 @@ opentelemetry-collector:
           # - name: cloud.region
           # - name: cloud.availability_zone
           ## Comment out all aws.ecs tags above if you uncomment this
-          # - name: aws.ecs.**
+          # - glob: aws.ecs.**
           ## Comment out all k8s.*.name tags above if you uncomment this
-          # - name: k8s.*.name
+          # - glob: k8s.*.name
       # Separate trace processing from sampling so span metrics are computed on all traces
       forward/traces_sample: {}
       # Runtime metric mapping adapted from https://docs.datadoghq.com/opentelemetry/integrations/runtime_metrics

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -321,13 +321,11 @@ opentelemetry-collector:
         
           ## Optional container tags
           ## May be used as additional primary tags or in service remapping rules
-          # - name: container.name
-          # - name: container.image.name
-          # - name: container.image.tag
-          # - name: container.runtime
           # # - name: cloud.provider
           # - name: cloud.region
           # - name: cloud.availability_zone
+          ## Comment out all container tags above if you uncomment this
+          # - glob: container.**
           ## Comment out all aws.ecs tags above if you uncomment this
           # - glob: aws.ecs.**
           ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -328,21 +328,10 @@ opentelemetry-collector:
           # # - name: cloud.provider
           # - name: cloud.region
           # - name: cloud.availability_zone
-          # - name: aws.ecs.task.family
-          # # - name: aws.ecs.task.arn
-          # - name: aws.ecs.cluster.arn
-          # - name: aws.ecs.task.revision
-          # - name: aws.ecs.container.arn
-          # - name: k8s.container.name
-          # # - name: k8s.cluster.name
-          # - name: k8s.deployment.name
-          # - name: k8s.replicaset.name
-          # - name: k8s.statefulset.name
-          # - name: k8s.daemonset.name
-          # - name: k8s.job.name
-          # - name: k8s.cronjob.name
-          # - name: k8s.namespace.name
-          # - name: k8s.pod.name
+          ## Comment out all aws.ecs tags above if you uncomment this
+          # - name: aws.ecs.**
+          ## Comment out all k8s.*.name tags above if you uncomment this
+          # - name: k8s.*.name
       # Separate trace processing from sampling so span metrics are computed on all traces
       forward/traces_sample: {}
       # Runtime metric mapping adapted from https://docs.datadoghq.com/opentelemetry/integrations/runtime_metrics

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -71,7 +71,7 @@ opentelemetry-collector:
   mode: daemonset
   image:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.152.0
+    tag: 0.154.0
   command:
     name: "otelcol-contrib"
     extraArgs: []

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -326,21 +326,10 @@ opentelemetry-collector:
           # # - name: cloud.provider
           # - name: cloud.region
           # - name: cloud.availability_zone
-          # - name: aws.ecs.task.family
-          # # - name: aws.ecs.task.arn
-          # - name: aws.ecs.cluster.arn
-          # - name: aws.ecs.task.revision
-          # - name: aws.ecs.container.arn
-          # - name: k8s.container.name
-          # # - name: k8s.cluster.name
-          # - name: k8s.deployment.name
-          # - name: k8s.replicaset.name
-          # - name: k8s.statefulset.name
-          # - name: k8s.daemonset.name
-          # - name: k8s.job.name
-          # - name: k8s.cronjob.name
-          # - name: k8s.namespace.name
-          # - name: k8s.pod.name
+          ## Comment out all aws.ecs tags above if you uncomment this
+          # - name: aws.ecs.**
+          ## Comment out all k8s.*.name tags above if you uncomment this
+          # - name: k8s.*.name
       # Separate trace processing from sampling so span metrics are computed on all traces
       forward/traces_sample: {}
       # Runtime metric mapping adapted from https://docs.datadoghq.com/opentelemetry/integrations/runtime_metrics

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -319,13 +319,11 @@ opentelemetry-collector:
         
           ## Optional container tags
           ## May be used as additional primary tags or in service remapping rules
-          # - name: container.name
-          # - name: container.image.name
-          # - name: container.image.tag
-          # - name: container.runtime
           # # - name: cloud.provider
           # - name: cloud.region
           # - name: cloud.availability_zone
+          ## Comment out all container tags above if you uncomment this
+          # - glob: container.**
           ## Comment out all aws.ecs tags above if you uncomment this
           # - glob: aws.ecs.**
           ## Comment out all k8s.*.name tags above if you uncomment this

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -327,9 +327,9 @@ opentelemetry-collector:
           # - name: cloud.region
           # - name: cloud.availability_zone
           ## Comment out all aws.ecs tags above if you uncomment this
-          # - name: aws.ecs.**
+          # - glob: aws.ecs.**
           ## Comment out all k8s.*.name tags above if you uncomment this
-          # - name: k8s.*.name
+          # - glob: k8s.*.name
       # Separate trace processing from sampling so span metrics are computed on all traces
       forward/traces_sample: {}
       # Runtime metric mapping adapted from https://docs.datadoghq.com/opentelemetry/integrations/runtime_metrics


### PR DESCRIPTION
Replaced `k8s` and `aws.ecs` attributes with corresponding glob expressions.