### PR TITLE
[OTEL-2983][configurations] Split payloads in 4 MB batches

### DIFF
--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -181,7 +181,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -183,7 +183,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -183,7 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -183,8 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -161,7 +161,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -163,7 +163,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -163,7 +163,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -163,8 +163,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -181,7 +181,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -183,7 +183,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -183,7 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -183,8 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -181,7 +181,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -183,7 +183,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -183,7 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -183,8 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -181,7 +181,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -183,7 +183,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -183,7 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -183,8 +183,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   # Report Collector status to Datadog for Fleet Automation

--- a/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
@@ -204,7 +204,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
@@ -206,7 +206,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
@@ -206,8 +206,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks-automatic.yaml
@@ -206,7 +206,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks.yaml
@@ -240,7 +240,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks.yaml
@@ -240,8 +240,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks.yaml
@@ -238,7 +238,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks.yaml
@@ -240,7 +240,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -242,7 +242,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -242,8 +242,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -242,7 +242,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -240,7 +240,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -202,7 +202,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -204,7 +204,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -204,7 +204,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -204,8 +204,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -238,8 +238,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -238,7 +238,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -238,7 +238,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -236,7 +236,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -238,8 +238,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -238,7 +238,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -238,7 +238,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -236,7 +236,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -14,5 +14,5 @@ compression_params:
 sending_queue:
   batch:
     sizer: bytes
-    min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-    max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+    min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+    max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -14,5 +14,5 @@ compression_params:
 sending_queue:
   batch:
     sizer: bytes
-    min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+    min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
     max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -12,4 +12,6 @@ compression: zstd
 compression_params:
   level: 3 # Level must be set explicitly for zstd
 sending_queue:
-  batch: {} # Default batch settings
+  batch:
+    sizer: bytes
+    max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)

--- a/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/otlp-http-exporter.tmpl
@@ -14,4 +14,5 @@ compression_params:
 sending_queue:
   batch:
     sizer: bytes
-    max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+    min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+    max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
@@ -274,8 +274,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
@@ -274,7 +274,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
@@ -272,7 +272,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
@@ -274,7 +274,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
@@ -309,7 +309,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
@@ -307,7 +307,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
@@ -309,7 +309,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
@@ -309,8 +309,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -311,7 +311,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -311,8 +311,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -311,7 +311,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -309,7 +309,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -272,7 +272,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -272,8 +272,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -272,7 +272,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -270,7 +270,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -305,7 +305,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -307,8 +307,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -307,7 +307,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke.yaml
@@ -307,7 +307,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -309,7 +309,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -307,7 +307,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -309,7 +309,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -309,8 +309,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
@@ -439,8 +439,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
@@ -437,7 +437,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
@@ -439,7 +439,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-aks.yaml
@@ -439,7 +439,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -441,8 +441,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -441,7 +441,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -439,7 +439,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -441,7 +441,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
@@ -437,7 +437,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
@@ -435,7 +435,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
@@ -437,7 +437,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-gke.yaml
@@ -437,8 +437,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -446,8 +446,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -446,7 +446,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -444,7 +444,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog.yaml
@@ -446,7 +446,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
@@ -371,7 +371,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
@@ -371,8 +371,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
@@ -369,7 +369,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-aks.yaml
@@ -371,7 +371,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -373,7 +373,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -373,7 +373,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -371,7 +371,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -373,8 +373,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
@@ -367,7 +367,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
@@ -369,7 +369,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
@@ -369,7 +369,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-gke.yaml
@@ -369,8 +369,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -376,7 +376,7 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
         max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -376,7 +376,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+        min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -374,7 +374,9 @@ exporters:
     compression_params:
       level: 3 # Level must be set explicitly for zstd
     sending_queue:
-      batch: {} # Default batch settings
+      batch:
+        sizer: bytes
+        max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog.yaml
@@ -376,8 +376,8 @@ exporters:
     sending_queue:
       batch:
         sizer: bytes
-        min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-        max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+        min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+        max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
 
 extensions:
   health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -440,7 +440,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -442,7 +442,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -442,8 +442,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -442,7 +442,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -447,8 +447,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+          min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+          max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -445,7 +445,9 @@ alternateConfig:
       compression_params:
         level: 3 # Level must be set explicitly for zstd
       sending_queue:
-        batch: {} # Default batch settings
+        batch:
+          sizer: bytes
+          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -447,7 +447,7 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
           max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog.yaml
@@ -447,7 +447,8 @@ alternateConfig:
       sending_queue:
         batch:
           sizer: bytes
-          max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+          min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+          max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
   
   extensions:
     health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -383,8 +383,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+            min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+            max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -401,8 +401,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+            min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+            max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
     
     extensions:
       health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -381,7 +381,9 @@ opentelemetry-collector:
         compression_params:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
-          batch: {} # Default batch settings
+          batch:
+            sizer: bytes
+            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -396,7 +398,9 @@ opentelemetry-collector:
         compression_params:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
-          batch: {} # Default batch settings
+          batch:
+            sizer: bytes
+            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
     
     extensions:
       health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -383,7 +383,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -400,7 +401,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
     
     extensions:
       health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -383,7 +383,7 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
             max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
@@ -401,7 +401,7 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
             max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
     
     extensions:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -381,7 +381,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -398,7 +399,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
+            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
     
     extensions:
       health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -381,8 +381,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+            min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+            max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -399,8 +399,8 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
-            max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
+            min_size: 2097152 # Start flushing batches at 2MiB (2 * 1024 * 1024)
+            max_size: 4194304 # Split large batches at 4MiB (4 * 1024 * 1024)
     
     extensions:
       health_check:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -381,7 +381,7 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
             max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
@@ -399,7 +399,7 @@ opentelemetry-collector:
         sending_queue:
           batch:
             sizer: bytes
-            min_size: 524288 # Accumulate at least 512KiB before flushing (512 * 1024)
+            min_size: 2097152 # Accumulate at least 2MiB before flushing (2 * 1024 * 1024)
             max_size: 4194304 # Flush batches at 4MiB (4 * 1024 * 1024)
     
     extensions:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -379,7 +379,9 @@ opentelemetry-collector:
         compression_params:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
-          batch: {} # Default batch settings
+          batch:
+            sizer: bytes
+            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
       otlp_http/dual_ship:
         endpoint: https://otlp.${env:DD_SITE_DUAL_SHIP}
         headers:
@@ -394,7 +396,9 @@ opentelemetry-collector:
         compression_params:
           level: 3 # Level must be set explicitly for zstd
         sending_queue:
-          batch: {} # Default batch settings
+          batch:
+            sizer: bytes
+            max_size: 4194304 # Flush batches at 4MB (4 * 1024 * 1024)
     
     extensions:
       health_check:


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds `batch` configuration to ensure all payloads stay under 4 MBs. This is below the intake limits which are 5.1MBs for metrics and logs and 15 MBs for traces.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Ensure payloads are below intake limits and users do not get 413 errors.
