### PR TITLE
Add DD_SITE env var to guides/kubernetes

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -145,8 +145,11 @@ helm install kube-state-metrics prometheus-community/kube-state-metrics
 # Export your API Key
 export DD_API_KEY=<YOUR API KEY>
 
+# Export your Datadog site: datadoghq.com, us3.datadoghq.com, datadoghq.eu...
+export DD_SITE=datadoghq.com
+
 # Create the secret on your cluster
-kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY
+kubectl create secret generic datadog-secret --from-literal="api-key=$DD_API_KEY" --from-literal="dd-site=${DD_SITE:-datadoghq.com}"
 ```
 
 #### Install the Collectors

--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -140,7 +140,7 @@ helm repo update
 helm install kube-state-metrics prometheus-community/kube-state-metrics
 ```
 
-#### Create the `DD_API_KEY` Kubernetes Secret
+#### Create the  Kubernetes Secret for `DD_API_KEY` and `DD_SITE`
 ```sh
 # Export your API Key
 export DD_API_KEY=<YOUR API KEY>

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -21,6 +21,12 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secret
         key: api-key
+  - name: DD_SITE  # datadoghq.com, us3.datadoghq.com, datadoghq.eu... Defaults to datadoghq.com
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secret
+        key: dd-site
+        optional: true
   - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
@@ -235,6 +241,7 @@ config:
     datadog/exporter:
       api:
         key: ${env:DD_API_KEY}
+        site: ${env:DD_SITE:-datadoghq.com}
       orchestrator_explorer:
         enabled: true
 

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -15,7 +15,12 @@ extraEnvs:
       secretKeyRef:
         name: datadog-secret
         key: api-key
-
+  - name: DD_SITE  # datadoghq.com, us3.datadoghq.com, datadoghq.eu... Defaults to datadoghq.com
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secret
+        key: dd-site
+        optional: true
 service:
   enabled: true
 
@@ -160,11 +165,13 @@ config:
     datadog/exporter:
       api:
         key: ${env:DD_API_KEY}
+        site: ${env:DD_SITE:-datadoghq.com}
 
   extensions:
     datadog:
       api:
         key: ${env:DD_API_KEY}
+        site: ${env:DD_SITE:-datadoghq.com}
       deployment_type: daemonset
 
   service:


### PR DESCRIPTION
### What does this PR do?

Add support for the `DD_SITE` en var.

### Motivation

The example in [guides/kubernetes](https://github.com/DataDog/opentelemetry-examples/tree/main/guides/kubernetes) doesn't include support for `DD_SITE` requiring tweaks when using other Datadog regions than datadoghq.com