### PR TITLE
Add Makefile to generate expanded helm charts config and help testing

### DIFF
--- a/guides/kubernetes/configuration/kube-stack/Makefile
+++ b/guides/kubernetes/configuration/kube-stack/Makefile
@@ -18,7 +18,6 @@ generate-examples:
 				open-telemetry/opentelemetry-kube-stack  \
 				--namespace opentelemetry-operator-system \
 				--version "0.20.0" \
-				--set-string clusterName="test_k8s_cluster" \
 				--values ./values.yaml --values $${value} \
 				--output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
 			mv $${EXAMPLES_DIR}/$${example}/rendered/opentelemetry-kube-stack/templates/* "$${EXAMPLES_DIR}/$${example}/rendered"; \

--- a/guides/kubernetes/configuration/kube-stack/Makefile
+++ b/guides/kubernetes/configuration/kube-stack/Makefile
@@ -1,0 +1,46 @@
+TMP_DIRECTORY = ./tmp
+chart_name = opentelemetry-kube-stack
+
+.PHONY: generate-examples
+generate-examples:
+	@echo "Generating all examples into their rendered/ subdirectory"
+	@mkdir -p $(TMP_DIRECTORY)
+	@# Iterate over all example directories
+	@echo "Current folder: $$(pwd)"; \
+	EXAMPLES_DIR=./examples; \
+	EXAMPLES=$$(find $${EXAMPLES_DIR} -maxdepth 1 -mindepth 1 -type d -exec basename \{\} \;); \
+	for example in $${EXAMPLES}; do \
+		echo "Generating example: $${example}"; \
+		VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name *values.yaml); \
+		rm -rf "$${EXAMPLES_DIR}/$${example}/rendered"; \
+		for value in $${VALUES}; do \
+			helm template opentelemetry-stack \
+				open-telemetry/opentelemetry-kube-stack  \
+				--namespace opentelemetry-operator-system \
+				--version "0.20.0" \
+				--set-string clusterName="test_k8s_cluster" \
+				--values ./values.yaml --values $${value} \
+				--output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
+			mv $${EXAMPLES_DIR}/$${example}/rendered/opentelemetry-kube-stack/templates/* "$${EXAMPLES_DIR}/$${example}/rendered"; \
+			SUBCHARTS_DIR=$${EXAMPLES_DIR}/$${example}/rendered/opentelemetry-kube-stack/charts; \
+			if [ -d "$${SUBCHARTS_DIR}" ]; then \
+				SUBCHARTS=$$(find $${SUBCHARTS_DIR} -maxdepth 1 -mindepth 1 -type d -exec basename \{\} \;); \
+				for subchart in $${SUBCHARTS}; do \
+					mkdir -p "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}"; \
+					mv $${SUBCHARTS_DIR}/$${subchart}/templates/* "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}"; \
+				done; \
+				rm -rf $${EXAMPLES_DIR}/$${example}/rendered/opentelemetry-kube-stack; \
+			fi; \
+		done; \
+	done; \
+	echo "Normalizing auto-generated certificate values"; \
+	if [ "$$(uname)" = "Darwin" ]; then \
+		find $${EXAMPLES_DIR} -name '*.yaml' -print0 | xargs -0 sed -i '' -e 's/\(caBundle:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' -e 's/\(tls\.crt:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' -e 's/\(tls\.key:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' -e 's/\(ca\.crt:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/'; \
+	else \
+		find $${EXAMPLES_DIR} -name '*.yaml' -exec sed -i'' \
+			-e 's/\(caBundle:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' \
+			-e 's/\(tls\.crt:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' \
+			-e 's/\(tls\.key:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' \
+			-e 's/\(ca\.crt:\) [A-Za-z0-9+/=]\{44,\}/\1 AUTO_GENERATED/' \
+			\{\} + ; \
+	fi

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/clusterrole.yaml
@@ -1,0 +1,190 @@
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opentelemetry-stack-collector
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - nodes
+  - nodes/pods
+  - nodes/metrics
+  - nodes/stats
+  - services
+  - endpoints
+  - pods
+  - events
+  - secrets
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  - podmonitors
+  - scrapeconfigs
+  - probes
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+
+- verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["namespaces", "pods", "nodes", "services", "serviceaccounts"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "networkpolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opentelemetry-stack-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opentelemetry-stack-collector
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "opentelemetry-stack-cluster-collector"
+  namespace: opentelemetry-operator-system
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opentelemetry-stack-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opentelemetry-stack-collector
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "opentelemetry-stack-daemon-collector"
+  namespace: opentelemetry-operator-system
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/collector.yaml
@@ -1,0 +1,813 @@
+---
+# Source: opentelemetry-kube-stack/templates/collector.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: opentelemetry-stack-cluster
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    release: "opentelemetry-stack"        
+spec:
+  managementState: managed
+  mode: deployment
+  config:
+    connectors:
+      count/k8s_entities:
+        datapoints:
+          k8s.deployment.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_deployment_created"
+          k8s.job.count:
+            conditions:
+            - metric.name == "kube_job_owner"
+          k8s.namespace.count:
+            conditions:
+            - metric.name == "kube_namespace_created"
+          k8s.node.count:
+            conditions:
+            - metric.name == "kube_node_info"
+          k8s.pod.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_pod_info"
+          k8s.service.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            - default_value: unspecified_service_type
+              key: type
+            conditions:
+            - metric.name == "kube_service_spec_type"
+    exporters:
+      datadog/exporter:
+        api:
+          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE:-datadoghq.com}
+        metrics:
+          resource_attributes_as_tags: true
+        orchestrator_explorer:
+          enabled: true
+    extensions:
+      datadog:
+        api:
+          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE:-datadoghq.com}
+        deployment_type: gateway
+      health_check: {}
+      k8s_leader_elector/k8s_cluster:
+        auth_type: serviceAccount
+        lease_name: k8s.cluster.receiver.opentelemetry.io
+        lease_namespace: opentelemetry-operator-system
+    processors:
+      cumulativetodelta: {}
+      filter/ksm:
+        metrics:
+          metric:
+          - metric.name == "kube_service_spec_type"
+          - metric.name == "kube_namespace_created"
+      groupbyattrs:
+        keys:
+        - k8s.pod.uid
+      k8s_attributes:
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+      resource_detection/env:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - aks
+        - eks
+        - gcp
+        - k8s_api
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: false
+        timeout: 15s
+      transform/ksm_to_dd:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["kube_namespace"], attributes["namespace"])
+          - delete_key(attributes, "namespace")
+          - set(attributes["kube_deployment"], attributes["deployment"])
+          - delete_key(attributes, "deployment")
+          - set(attributes["pod_phase"], attributes["phase"])
+          - delete_key(attributes, "phase")
+          - set(attributes["kube_stateful_set"], attributes["statefulset"])
+          - delete_key(attributes, "statefulset")
+          - set(attributes["kube_daemon_set"], attributes["daemonset"])
+          - delete_key(attributes, "daemonset")
+          - set(attributes["kube_replica_set"], attributes["replicaset"])
+          - delete_key(attributes, "replicaset")
+          - set(attributes["kube_job"], attributes["job_name"])
+          - delete_key(attributes, "job_name")
+          - set(attributes["kube_service"], attributes["service"])
+          - delete_key(attributes, "service")
+      transform/rename_uid:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.uid"], attributes["uid"])
+          - delete_key(attributes, "uid")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
+      transform/sum_to_gauge:
+        metric_statements:
+        - convert_sum_to_gauge() where metric.name == "k8s.service.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.node.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.job.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        - storage
+        auth_type: serviceAccount
+        collection_interval: 10s
+        k8s_leader_elector: k8s_leader_elector/k8s_cluster
+        node_conditions_to_report:
+        - Ready
+        - MemoryPressure
+        - DiskPressure
+        - NetworkUnavailable
+      k8s_objects:
+        interval: 3m
+        objects:
+        - mode: pull
+          name: namespaces
+        - mode: watch
+          name: namespaces
+        - mode: pull
+          name: pods
+        - mode: watch
+          name: pods
+        - mode: pull
+          name: nodes
+        - mode: watch
+          name: nodes
+        - mode: pull
+          name: services
+        - mode: watch
+          name: services
+        - mode: pull
+          name: serviceaccounts
+        - mode: watch
+          name: serviceaccounts
+        - group: apps
+          mode: pull
+          name: deployments
+        - group: apps
+          mode: watch
+          name: deployments
+        - group: apps
+          mode: pull
+          name: replicasets
+        - group: apps
+          mode: watch
+          name: replicasets
+        - group: apps
+          mode: pull
+          name: daemonsets
+        - group: apps
+          mode: watch
+          name: daemonsets
+        - group: apps
+          mode: pull
+          name: statefulsets
+        - group: apps
+          mode: watch
+          name: statefulsets
+        - group: batch
+          mode: pull
+          name: jobs
+        - group: batch
+          mode: watch
+          name: jobs
+        - group: batch
+          mode: pull
+          name: cronjobs
+        - group: batch
+          mode: watch
+          name: cronjobs
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: roles
+        - group: rbac.authorization.k8s.io
+          mode: watch
+          name: roles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: watch
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterrolebindings
+        - group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterrolebindings
+        - group: storage.k8s.io
+          mode: pull
+          name: storageclasses
+        - group: storage.k8s.io
+          mode: watch
+          name: storageclasses
+        - mode: pull
+          name: persistentvolumes
+        - mode: watch
+          name: persistentvolumes
+        - mode: pull
+          name: persistentvolumeclaims
+        - mode: watch
+          name: persistentvolumeclaims
+        - group: networking.k8s.io
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          mode: watch
+          name: ingresses
+        - group: networking.k8s.io
+          mode: pull
+          name: networkpolicies
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: autoscaling
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: autoscaling
+          mode: watch
+          name: horizontalpodautoscalers
+        - group: policy
+          mode: pull
+          name: poddisruptionbudgets
+        - group: policy
+          mode: watch
+          name: poddisruptionbudgets
+        - group: apiextensions.k8s.io
+          mode: pull
+          name: customresourcedefinitions
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/ksm:
+        config:
+          scrape_configs:
+          - job_name: kube-state-metrics
+            metric_relabel_configs:
+            - action: keep
+              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              source_labels:
+              - __name__
+            metrics_path: /metrics
+            scheme: http
+            static_configs:
+            - targets:
+              - kube-state-metrics:8080
+    service:
+      extensions:
+      - health_check
+      - datadog
+      - k8s_leader_elector/k8s_cluster
+      pipelines:
+        logs:
+          exporters:
+          - datadog/exporter
+          processors:
+          - k8s_attributes
+          - resource_detection/env
+          receivers:
+          - k8s_objects
+          - otlp
+        metrics:
+          exporters:
+          - datadog/exporter
+          processors:
+          - filter/ksm
+          - resource_detection/env
+          - transform/ksm_to_dd
+          - transform/rename_uid
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - transform/sum_to_gauge
+          receivers:
+          - otlp
+          - prometheus/ksm
+          - count/k8s_entities
+          - k8s_cluster
+        metrics/count:
+          exporters:
+          - count/k8s_entities
+          receivers:
+          - prometheus/ksm
+      telemetry:
+        logs:
+          processors:
+          - batch:
+              exporter:
+                otlp:
+                  endpoint: http://localhost:4318
+                  protocol: http/protobuf
+        metrics:
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: http://localhost:4318
+                  protocol: http/protobuf
+  replicas: 1
+  imagePullPolicy: IfNotPresent
+  upgradeStrategy: automatic
+  terminationGracePeriodSeconds: 30
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 500Mi
+  securityContext:
+    {}
+  env:
+  - name: K8S_NODE_NAME 
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: OTEL_K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.namespace
+  - name: OTEL_K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  - name: OTEL_K8S_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=test_k8s_cluster"
+  
+  - name: DD_API_KEY
+    valueFrom:
+      secretKeyRef:
+        key: api-key
+        name: datadog-secret
+  - name: DD_SITE
+    valueFrom:
+      secretKeyRef:
+        key: dd-site
+        name: datadog-secret
+        optional: true
+---
+# Source: opentelemetry-kube-stack/templates/collector.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: opentelemetry-stack-daemon
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    release: "opentelemetry-stack"        
+spec:
+  managementState: managed
+  mode: daemonset
+  config:
+    connectors:
+      datadog/connector: {}
+    exporters:
+      datadog/exporter:
+        api:
+          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE:-datadoghq.com}
+        metrics:
+          resource_attributes_as_tags: true
+      debug: {}
+    extensions:
+      datadog:
+        api:
+          key: ${env:DD_API_KEY}
+          site: ${env:DD_SITE:-datadoghq.com}
+        deployment_type: daemonset
+      health_check: {}
+    processors:
+      batch:
+        send_batch_max_size: 1500
+        send_batch_size: 1000
+        timeout: 1s
+      cumulativetodelta: {}
+      deltatorate:
+        metrics:
+        - k8s.pod.network.io
+        - k8s.pod.network.errors
+      k8s_attributes:
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        filter:
+          node_from_env_var: OTEL_K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resource/hostname:
+        attributes:
+        - action: insert
+          from_attribute: k8s.node.name
+          key: host.name
+      resource_detection/env:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - aks
+        - eks
+        - gcp
+        - k8s_api
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: false
+        timeout: 15s
+    receivers:
+      file_log:
+        exclude: []
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: container-parser
+          max_log_size: 102400
+          type: container
+        retry_on_failure:
+          enabled: true
+        start_at: end
+      host_metrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.logical.count:
+                enabled: true
+              system.cpu.utilization:
+                enabled: true
+          disk: {}
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+            metrics:
+              system.filesystem.utilization:
+                enabled: true
+          load: {}
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
+          network: {}
+          paging:
+            metrics:
+              system.paging.usage:
+                enabled: true
+          system:
+            metrics:
+              system.uptime:
+                enabled: true
+      kubelet_stats:
+        auth_type: serviceAccount
+        collection_interval: 15s
+        endpoint: https://${env:OTEL_K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        - k8s.volume.type
+        insecure_skip_verify: true
+        k8s_api_config:
+          auth_type: serviceAccount
+        metric_groups:
+        - node
+        - pod
+        - volume
+        - container
+        metrics:
+          container.cpu.usage:
+            enabled: true
+          k8s.node.cpu.usage:
+            enabled: true
+          k8s.node.uptime:
+            enabled: true
+          k8s.pod.cpu.usage:
+            enabled: true
+          k8s.pod.uptime:
+            enabled: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    service:
+      extensions:
+      - health_check
+      - datadog
+      pipelines:
+        logs:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - k8s_attributes
+          receivers:
+          - otlp
+          - file_log
+        metrics:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate
+          receivers:
+          - datadog/connector
+          - otlp
+          - host_metrics
+          - kubelet_stats
+        traces:
+          exporters:
+          - datadog/connector
+          processors:
+          - resource_detection/env
+          - k8s_attributes
+          receivers:
+          - otlp
+        traces/sampling:
+          exporters:
+          - datadog/exporter
+          receivers:
+          - datadog/connector
+      telemetry:
+        logs:
+          processors:
+          - batch:
+              exporter:
+                otlp:
+                  endpoint: http://localhost:4318
+                  protocol: http/protobuf
+        metrics:
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: http://localhost:4318
+                  protocol: http/protobuf
+  imagePullPolicy: IfNotPresent
+  upgradeStrategy: automatic
+  terminationGracePeriodSeconds: 30
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 500Mi
+  securityContext:
+    {}
+  volumeMounts:
+  - name: varlogpods
+    mountPath: /var/log/pods
+    readOnly: true
+  - name: varlibdockercontainers
+    mountPath: /var/lib/docker/containers
+    readOnly: true
+  - name: hostfs
+    mountPath: /hostfs
+    readOnly: true
+    mountPropagation: HostToContainer
+  env:
+  - name: K8S_NODE_NAME 
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: OTEL_K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.namespace
+  - name: OTEL_K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  - name: OTEL_K8S_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=test_k8s_cluster"
+  
+  - name: DD_API_KEY
+    valueFrom:
+      secretKeyRef:
+        key: api-key
+        name: datadog-secret
+  - name: DD_SITE
+    valueFrom:
+      secretKeyRef:
+        key: dd-site
+        name: datadog-secret
+        optional: true
+  volumes:
+  - name: varlogpods
+    hostPath:
+      path: /var/log/pods
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: hostfs
+    hostPath:
+      path: /
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/hooks.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-resources-sa
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: delete-resources-role
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opampbridges
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - delete
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: delete-resources-rolebinding
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: delete-resources-role
+subjects:
+  - kind: ServiceAccount
+    name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opentelemetry-kube-stack-pre-delete-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: delete-resources-sa
+      containers:
+      - name: delete-resources
+        image: "rancher/kubectl:v1.34.1"
+        args:
+          - "delete"
+          - "instrumentations,opampbridges,opentelemetrycollectors"
+          - "-l"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: opentelemetry-operator-system

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/deployment.yaml
@@ -1,0 +1,89 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: opentelemetry-operator-system
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: opentelemetry-stack
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-6.3.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: opentelemetry-stack
+        app.kubernetes.io/version: "2.17.0"
+        release: opentelemetry-stack
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
+        ports:
+        - containerPort: 8080
+          name: http
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/role.yaml
@@ -1,0 +1,158 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+  name: kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/service.yaml
@@ -1,0 +1,30 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: opentelemetry-operator-system
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: http
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/serviceaccount.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+  name: kube-state-metrics
+  namespace: opentelemetry-operator-system

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/kube-state-metrics/servicemonitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-kube-stack/charts/kube-state-metrics/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: opentelemetry-operator-system
+  labels:    
+    helm.sh/chart: kube-state-metrics-6.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/version: "2.17.0"
+    release: opentelemetry-stack
+spec:
+  jobLabel: app.kubernetes.io/name  
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: opentelemetry-stack
+  endpoints:
+    - port: http
+      honorLabels: true
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -1,0 +1,193 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-stack-opentelemetry-operator-serving-cert
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-stack-opentelemetry-operator-mutation
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /mutate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: minstrumentation.kb.io
+    rules:
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /mutate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: mopentelemetrycollectorbeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /mutate-v1-pod
+        port: 443
+    failurePolicy: Ignore
+    name: mpod.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-stack-opentelemetry-operator-serving-cert
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-stack-opentelemetry-operator-validation
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: vinstrumentationcreateupdate.kb.io
+    rules:
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: vinstrumentationdelete.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - DELETE
+        resources:
+          - instrumentations
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /validate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: vopentelemetrycollectorcreateupdatebeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opentelemetry-stack-opentelemetry-operator-webhook
+        namespace: opentelemetry-operator-system
+        path: /validate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: vopentelemetrycollectordeletebeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - DELETE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -1,0 +1,8 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
@@ -1,0 +1,44 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-stack-opentelemetry-operator-serving-cert
+  namespace: opentelemetry-operator-system
+spec:
+  dnsNames:
+    - opentelemetry-stack-opentelemetry-operator-webhook.opentelemetry-operator-system.svc
+    - opentelemetry-stack-opentelemetry-operator-webhook.opentelemetry-operator-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: opentelemetry-stack-opentelemetry-operator-selfsigned-issuer
+  secretName: opentelemetry-stack-opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - opentelemetry-stack-opentelemetry-operator
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-stack-opentelemetry-operator-selfsigned-issuer
+  namespace: opentelemetry-operator-system
+spec:
+  selfSigned: {}
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -1,0 +1,420 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/spec
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+      - targetallocators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificaterequests
+      - certificates
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-metrics
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opentelemetry-stack-opentelemetry-operator-manager
+subjects:
+  - kind: ServiceAccount
+    name: opentelemetry-operator
+    namespace: opentelemetry-operator-system
+
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
@@ -1,0 +1,105 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator
+  namespace: opentelemetry-operator-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        helm.sh/chart: opentelemetry-operator-0.119.0
+        app.kubernetes.io/name: opentelemetry-operator
+        app.kubernetes.io/version: "0.154.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: opentelemetry-operator
+        app.kubernetes.io/instance: opentelemetry-stack
+        app.kubernetes.io/component: controller-manager
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      containers:
+        - args:
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
+            - --enable-leader-election
+            - --health-probe-addr=:8081
+            - --webhook-port=9443
+            - --collector-image=otel/opentelemetry-collector-contrib:0.154.0
+          command:
+            - /manager
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: ENABLE_WEBHOOKS
+              value: "true"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.154.0"
+          name: manager
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: 
+            {}
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector: 
+        kubernetes.io/os: linux
+      serviceAccountName: opentelemetry-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: opentelemetry-stack-opentelemetry-operator-controller-manager-service-cert
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
@@ -1,0 +1,200 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-leader-election
+  namespace: opentelemetry-operator-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+      - targetallocators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+      - opentelemetrycollectors/finalizers
+      - opentelemetrycollectors/status
+      - targetallocators/status
+      - targetallocators/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-leader-election
+  namespace: opentelemetry-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: opentelemetry-stack-opentelemetry-operator-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: opentelemetry-operator
+    namespace: opentelemetry-operator-system
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
@@ -1,0 +1,48 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator
+  namespace: opentelemetry-operator-system
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      protocol: TCP
+      targetPort: metrics
+  selector:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  name: opentelemetry-stack-opentelemetry-operator-webhook
+  namespace: opentelemetry-operator-system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: webhook-server
+  selector:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -1,0 +1,60 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "opentelemetry-stack-opentelemetry-operator-cert-manager"
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: webhook
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: CERT_MANAGER_CLUSTERIP
+          value: "cert-manager-webhook.cert-manager"
+        - name: CERT_MANAGER_PORT
+          value: "443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the cert-manager service is up. If the service is up, when we try
+        # to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$CERT_MANAGER_CLUSTERIP:$CERT_MANAGER_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -1,0 +1,119 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "opentelemetry-stack-opentelemetry-operator-metrics-test"
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: MANAGER_METRICS_SERVICE_CLUSTERIP
+          value: "opentelemetry-stack-opentelemetry-operator"
+        - name: MANAGER_METRICS_SERVICE_PORT
+          value: "8443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the controller-manager-metrics-service is up.
+        # If the service is up, when we try to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$MANAGER_METRICS_SERVICE_CLUSTERIP:$MANAGER_METRICS_SERVICE_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "opentelemetry-stack-opentelemetry-operator-webhook-test"
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-stack
+    app.kubernetes.io/component: controller-manager
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: WEBHOOK_SERVICE_CLUSTERIP
+          value: "opentelemetry-stack-opentelemetry-operator-webhook"
+        - name: WEBHOOK_SERVICE_PORT
+          value: "443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the webhook service is up. If the service is up, when we try
+        # to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$WEBHOOK_SERVICE_CLUSTERIP:$WEBHOOK_SERVICE_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+

--- a/guides/kubernetes/configuration/kube-stack/examples/default/values.yaml
+++ b/guides/kubernetes/configuration/kube-stack/examples/default/values.yaml
@@ -1,0 +1,1 @@
+clusterName: a_k8s_cluster


### PR DESCRIPTION
### What does this PR do?

Add Makefile to generate expanded helm charts config and help testing

Similar to the upstream [otel helm charts](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main) testing framework like https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack/examples/default

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
