### PR TITLE
Remove preview labeling from the README.md

### DIFF
--- a/guides/kubernetes/README.md
+++ b/guides/kubernetes/README.md
@@ -1,8 +1,3 @@
-> [!IMPORTANT]  
-> OTel Kubernetes Metrics Remapping is in closed preview. If you would like to participate, please reach out to your account team.
-
-</br>
-
 # Kubernetes Integration
 This guide documents how to configure OpenTelemetry collectors to support Datadog's Kubernetes Integration.
 


### PR DESCRIPTION
### What does this PR do?

Update the readme file to remove the preview label. The kubernetes pipelines are now GA and customers are free to utilize them


### Motivation

GA of Kubernetes metric support and the Kubernetes Explorer