### PR TITLE
[OTEL-3014] Add EKS Auto config + minor improvements

### DIFF
--- a/configurations/opentelemetry-collector/README.md
+++ b/configurations/opentelemetry-collector/README.md
@@ -48,6 +48,7 @@ Files:
 - `daemonset-aks.yaml`: Kubernetes Daemonset in an AKS environment
 - `daemonset-aks-automatic.yaml`: Kubernetes Daemonset in an AKS Automatic environment
 - `daemonset-eks.yaml`: Kubernetes Daemonset in an EKS environment
+- `daemonset-eks-auto.yaml`: Kubernetes Daemonset in an EKS Auto Mode environment
 - `daemonset-gke.yaml`: Kubernetes Daemonset in a GKE environment
 - `daemonset-gke-autopilot.yaml`: Kubernetes Daemonset in a GKE Autopilot environment
 - `k8s-objects-datadog.yaml`: Kubernetes per-cluster Deployment (k8s_objects) in a non-cloud environment using the Datadog exporter
@@ -77,6 +78,7 @@ Files:
 - `helm-values/daemonset-aks.yaml`: Kubernetes Daemonset in an AKS environment
 - `helm-values/daemonset-aks-automatic.yaml`: Kubernetes Daemonset in an AKS Automatic environment
 - `helm-values/daemonset-eks.yaml`: Kubernetes Daemonset in an EKS environment
+- `helm-values/daemonset-eks-auto.yaml`: Kubernetes Daemonset in an EKS Auto Mode environment
 - `helm-values/daemonset-gke.yaml`: Kubernetes Daemonset in a GKE Standard environment
 - `helm-values/daemonset-gke-autopilot.yaml`: Kubernetes Daemonset in a GKE Autopilot environment
 - `helm-values/k8s-objects-datadog.yaml`: Kubernetes per-cluster Deployment (k8s_objects) in a non-cloud environment using the Datadog exporter

--- a/configurations/opentelemetry-collector/agent-azure.yaml
+++ b/configurations/opentelemetry-collector/agent-azure.yaml
@@ -48,7 +48,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [azure, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -202,20 +202,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [otlp_http]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/agent-container.yaml
+++ b/configurations/opentelemetry-collector/agent-container.yaml
@@ -51,7 +51,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [env]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -182,20 +182,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [otlp_http]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/agent-ec2.yaml
+++ b/configurations/opentelemetry-collector/agent-ec2.yaml
@@ -48,7 +48,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [ec2, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -202,20 +202,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [otlp_http]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/agent-gce.yaml
+++ b/configurations/opentelemetry-collector/agent-gce.yaml
@@ -48,7 +48,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [gcp, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -202,20 +202,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [otlp_http]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/agent.yaml
+++ b/configurations/opentelemetry-collector/agent.yaml
@@ -48,7 +48,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -202,20 +202,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [otlp_http]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-aks.yaml
@@ -62,7 +62,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [aks, azure, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -263,14 +263,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics, kubelet_stats]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
         - deltatorate
       exporters: [otlp_http]
@@ -279,7 +279,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/daemonset-eks-auto.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks-auto.yaml
@@ -65,7 +65,7 @@ processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resource_detection:
     detectors: [eks, env, system]
-    timeout: 2s
+    timeout: 15s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
     eks:
       resource_attributes:

--- a/configurations/opentelemetry-collector/daemonset-eks-auto.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks-auto.yaml
@@ -1,10 +1,12 @@
 # Recommended OpenTelemetry Collector configuration
-# Setup: Kubernetes Daemonset in an AKS Automatic environment
+# Setup: Kubernetes Daemonset in an EKS Auto Mode environment
 # Collector Contrib version: v0.154.0
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key
-# - K8S_NODE_NAME: The name of the Kubernetes node (used by the kubelet_stats receiver)
+# - K8S_NODE_NAME: The name of the Kubernetes node (used by the kubelet_stats receiver / EKS detector)
+# Required mounts: /hostfs
+# The EKS resource detector requires a Pod Identity association assigning the Collector an IAM role with the `EC2:DescribeInstances` permission.
 
 receivers:
   # Receive telemetry from OpenTelemetry-instrumented applications
@@ -14,6 +16,39 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
+  # Collect host-level metrics for the Infrastructure List
+  host_metrics:
+    root_path: /hostfs # Necessary inside containers, corresponds to / on host
+    collection_interval: 10s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+          system.cpu.physical.count:
+            enabled: true
+          system.cpu.logical.count:
+            enabled: true
+          system.cpu.frequency:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.limit:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+          system.paging.usage:
+            enabled: true
+      disk: {}
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      load: {}
+      network: {}
+      processes: {}
   kubelet_stats:
     collection_interval: 15s
     auth_type: "serviceAccount"
@@ -29,12 +64,21 @@ receivers:
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resource_detection:
-    detectors: [aks, azure, env, system]
+    detectors: [eks, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
-    aks:
+    eks:
       resource_attributes:
         k8s.cluster.name: { enabled: true }
+        host.id: { enabled: true } # Necessary for host name inference
+        cloud.account.id: { enabled: true }
+        cloud.availability_zone: { enabled: true }
+        cloud.region: { enabled: true }
+        host.image.id: { enabled: true }
+        host.type: { enabled: true }
+      node_from_env_var: K8S_NODE_NAME
+    ec2:
+      tags: ['^kubernetes\.io/cluster/.*$']
     system:
       resource_attributes:
         host.name:
@@ -233,7 +277,7 @@ service:
       exporters: [otlp_http]
     
     metrics:
-      receivers: [otlp, kubelet_stats]
+      receivers: [otlp, host_metrics, kubelet_stats]
       processors:
         - k8s_attributes
         - resource_detection

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -66,7 +66,7 @@ processors:
   # Detect host and cloud metadata for hostname resolution and tagging
   resource_detection:
     detectors: [eks, ec2, env, system]
-    timeout: 2s
+    timeout: 15s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
     eks:
       resource_attributes:

--- a/configurations/opentelemetry-collector/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/daemonset-eks.yaml
@@ -6,6 +6,8 @@
 # - DD_API_KEY: A Datadog API key
 # - K8S_NODE_NAME: The name of the Kubernetes node (used by the kubelet_stats receiver)
 # Required mounts: /hostfs
+# The EC2 and EKS resource detectors requires access to the IMDS endpoint from within a container,
+# which requires setting the IMDS Token Hop Limit to 2 in either the node launch template or account settings.
 
 receivers:
   # Receive telemetry from OpenTelemetry-instrumented applications
@@ -62,7 +64,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [eks, ec2, env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -265,14 +267,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics, kubelet_stats]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
         - deltatorate
       exporters: [otlp_http]
@@ -281,7 +283,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke-autopilot.yaml
@@ -28,7 +28,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [gcp, env, system]
     # If using older unsupported versions of GKE, you may need to supply the node name as `host.name` in `OTEL_RESOURCE_ATTRIBUTES`
     timeout: 2s
@@ -227,14 +227,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, kubelet_stats]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
         - deltatorate
       exporters: [otlp_http]
@@ -243,7 +243,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/daemonset-gke.yaml
+++ b/configurations/opentelemetry-collector/daemonset-gke.yaml
@@ -62,7 +62,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [gcp, env, system]
     # If using older unsupported versions of GKE, you may need to supply the node name as `host.name` in `OTEL_RESOURCE_ATTRIBUTES`
     timeout: 2s
@@ -261,14 +261,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics, kubelet_stats]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
         - deltatorate
       exporters: [otlp_http]
@@ -277,7 +277,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/daemonset.yaml
+++ b/configurations/opentelemetry-collector/daemonset.yaml
@@ -63,7 +63,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -261,14 +261,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [otlp_http]
     
     metrics:
       receivers: [otlp, host_metrics, kubelet_stats]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
         - deltatorate
       exporters: [otlp_http]
@@ -277,7 +277,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [forward/traces_sample, span_metrics]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/generator/configs.go
+++ b/configurations/opentelemetry-collector/generator/configs.go
@@ -4,7 +4,7 @@ var otelcolVersion = "0.154.0"
 
 var hostEnvs = []string{"", "ec2", "gce", "azure"}
 
-var k8sDaemonsetEnvs = []string{"", "eks", "gke", "gke-autopilot", "aks", "aks-automatic"}
+var k8sDaemonsetEnvs = []string{"", "eks", "eks-auto", "gke", "gke-autopilot", "aks", "aks-automatic"}
 var k8sDeploymentEnvs = []string{"", "eks", "gke", "aks"}
 
 var configs = []config{

--- a/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
@@ -23,7 +23,11 @@ detectors: [env{{$kubeadm}}{{$system}}]
 {{- else }}
 {{- errorf "unknown cloud environment %q" .CloudEnvironment}}
 {{- end}}
+{{- if eq .CloudEnvironment "eks" "eks-auto"}}
+timeout: 15s {{- /* The EKS detector docs recommend increasing the timeout */}}
+{{- else}}
 timeout: 2s
+{{- end}}
 override: true # Disable if incoming attributes (especially host.name) are verified correct
 {{- if .K8sObjects}}
 # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes

--- a/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/components/resource-detection-processor.tmpl
@@ -7,6 +7,8 @@
 detectors: [ec2, env{{$kubeadm}}{{$system}}]
 {{- else if eq .CloudEnvironment "eks" }}
 detectors: [eks, ec2, env{{$kubeadm}}{{$system}}]
+{{- else if eq .CloudEnvironment "eks-auto" }}
+detectors: [eks, env{{$kubeadm}}{{$system}}]
 {{- else if eq .CloudEnvironment "gce" "gke" "gke-autopilot" }}
 detectors: [gcp, env{{$kubeadm}}{{$system}}]
 {{- if eq .CloudEnvironment "gke" "gke-autopilot" }}
@@ -35,10 +37,19 @@ aks:
   resource_attributes:
     k8s.cluster.name: { enabled: true }
 {{- end}}
-{{- if eq .CloudEnvironment "eks"}}
+{{- if eq .CloudEnvironment "eks" "eks-auto"}}
 eks:
   resource_attributes:
     k8s.cluster.name: { enabled: true }
+  {{- if eq .CloudEnvironment "eks-auto"}}
+    host.id: { enabled: true } # Necessary for host name inference
+    cloud.account.id: { enabled: true }
+    cloud.availability_zone: { enabled: true }
+    cloud.region: { enabled: true }
+    host.image.id: { enabled: true }
+    host.type: { enabled: true }
+  node_from_env_var: K8S_NODE_NAME
+  {{- end}}
 ec2:
   tags: ['^kubernetes\.io/cluster/.*$']
 {{- end}}

--- a/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/otelcol-agent.tmpl
@@ -1,22 +1,37 @@
 {{- if .Preamble -}}
+
 {{- if .Testing -}}
 # FOR INTERNAL TESTING PURPOSES ONLY
 {{end -}}
+
 # Recommended OpenTelemetry Collector configuration
 {{include "setup" .}}
 # Collector Contrib version: v{{.OtelcolVersion}}
 # Required environment variables:
 # - DD_SITE: Datadog site for your region, e.g. datadog.com
 # - DD_API_KEY: A Datadog API key
-{{- if .KubeletStats}}
-# - K8S_NODE_NAME: The name of the Kubernetes node (used by the kubelet_stats receiver)
+
+{{- if or .KubeletStats (eq .CloudEnvironment "eks-auto")}}
+# - K8S_NODE_NAME: The name of the Kubernetes node (used by the kubelet_stats receiver{{- if eq .CloudEnvironment "eks-auto"}} / EKS detector{{- end}})
 {{- end}}
+
 {{- if and .Container (eq .CloudEnvironment "")}}
 # - OTEL_RESOURCE_ATTRIBUTES: Host information (no host detection possible in this setup)
 {{- end}}
+
 {{- if and .Container (not .NoHostMetrics)}}
 # Required mounts: /hostfs
 {{- end}}
+
+{{- end}}
+
+{{- if eq .CloudEnvironment "eks-auto"}}
+# The EKS resource detector requires a Pod Identity association assigning the Collector an IAM role with the `EC2:DescribeInstances` permission.
+{{- end}}
+
+{{- if eq .CloudEnvironment "eks"}}
+# The EC2 and EKS resource detectors requires access to the IMDS endpoint from within a container,
+# which requires setting the IMDS Token Hop Limit to 2 in either the node launch template or account settings.
 {{- end}}
 
 receivers:
@@ -35,7 +50,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     {{include "resource-detection-processor" . | indent 4}}
   {{- if .K8s}}
   k8s_attributes:
@@ -160,7 +175,7 @@ service:
         {{- if .K8s}}
         - k8s_attributes
         {{- end}}
-        - resourcedetection
+        - resource_detection
       {{- if .DatadogExporter}}
       exporters: [datadog]
       {{- else if .DualShip}}
@@ -175,7 +190,7 @@ service:
         {{- if .K8s}}
         - k8s_attributes
         {{- end}}
-        - resourcedetection
+        - resource_detection
     {{- if .MapEquivalentMetrics}}
       exporters: [routing/metrics]
     
@@ -211,7 +226,7 @@ service:
         {{- if .K8s}}
         - k8s_attributes
         {{- end}}
-        - resourcedetection
+        - resource_detection
       {{- if .DatadogExporter}}
       exporters: [datadog/connector]
       {{- else}}

--- a/configurations/opentelemetry-collector/generator/templates/snippets/setup.tmpl
+++ b/configurations/opentelemetry-collector/generator/templates/snippets/setup.tmpl
@@ -14,6 +14,8 @@
 {{- $environment = "an EC2" }}
 {{- else if eq .CloudEnvironment "eks" -}}
 {{- $environment = "an EKS" }}
+{{- else if eq .CloudEnvironment "eks-auto" -}}
+{{- $environment = "an EKS Auto Mode" }}
 {{- else if eq .CloudEnvironment "gce" -}}
 {{- $environment = "a GCE" }}
 {{- else if eq .CloudEnvironment "gke" -}}

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks-automatic.yaml
@@ -98,7 +98,7 @@ alternateConfig:
   
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
-    resourcedetection:
+    resource_detection:
       detectors: [aks, azure, env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -297,14 +297,14 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [otlp_http]
       
       metrics:
         receivers: [otlp, kubelet_stats]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
           - cumulativetodelta
           - deltatorate
         exporters: [otlp_http]
@@ -313,7 +313,7 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [forward/traces_sample, span_metrics]
       
       traces/sample:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-aks.yaml
@@ -133,7 +133,7 @@ alternateConfig:
   
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
-    resourcedetection:
+    resource_detection:
       detectors: [aks, azure, env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -332,14 +332,14 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [otlp_http]
       
       metrics:
         receivers: [otlp, host_metrics, kubelet_stats]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
           - cumulativetodelta
           - deltatorate
         exporters: [otlp_http]
@@ -348,7 +348,7 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [forward/traces_sample, span_metrics]
       
       traces/sample:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks-auto.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks-auto.yaml
@@ -1,5 +1,5 @@
 # Recommended values.yaml for the OpenTelemetry Collector Helm Chart
-# Setup: Kubernetes Daemonset in a GKE environment
+# Setup: Kubernetes Daemonset in an EKS Auto Mode environment
 # Required secrets: datadog-secrets::api-key
 # Remember to modify DD_SITE if not using datadoghq.com
 
@@ -78,6 +78,8 @@ startupProbe:
     path: /
 
 alternateConfig:
+  # The EKS resource detector requires a Pod Identity association assigning the Collector an IAM role with the `EC2:DescribeInstances` permission.
+  
   receivers:
     # Receive telemetry from OpenTelemetry-instrumented applications
     otlp:
@@ -134,10 +136,21 @@ alternateConfig:
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
     resource_detection:
-      detectors: [gcp, env, system]
-      # If using older unsupported versions of GKE, you may need to supply the node name as `host.name` in `OTEL_RESOURCE_ATTRIBUTES`
+      detectors: [eks, env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
+      eks:
+        resource_attributes:
+          k8s.cluster.name: { enabled: true }
+          host.id: { enabled: true } # Necessary for host name inference
+          cloud.account.id: { enabled: true }
+          cloud.availability_zone: { enabled: true }
+          cloud.region: { enabled: true }
+          host.image.id: { enabled: true }
+          host.type: { enabled: true }
+        node_from_env_var: K8S_NODE_NAME
+      ec2:
+        tags: ['^kubernetes\.io/cluster/.*$']
       system:
         resource_attributes:
           host.name:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks-auto.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks-auto.yaml
@@ -137,7 +137,7 @@ alternateConfig:
     # Detect host and cloud metadata for hostname resolution and tagging
     resource_detection:
       detectors: [eks, env, system]
-      timeout: 2s
+      timeout: 15s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       eks:
         resource_attributes:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -78,6 +78,9 @@ startupProbe:
     path: /
 
 alternateConfig:
+  # The EC2 and EKS resource detectors requires access to the IMDS endpoint from within a container,
+  # which requires setting the IMDS Token Hop Limit to 2 in either the node launch template or account settings.
+  
   receivers:
     # Receive telemetry from OpenTelemetry-instrumented applications
     otlp:
@@ -133,7 +136,7 @@ alternateConfig:
   
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
-    resourcedetection:
+    resource_detection:
       detectors: [eks, ec2, env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -334,14 +337,14 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [otlp_http]
       
       metrics:
         receivers: [otlp, host_metrics, kubelet_stats]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
           - cumulativetodelta
           - deltatorate
         exporters: [otlp_http]
@@ -350,7 +353,7 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [forward/traces_sample, span_metrics]
       
       traces/sample:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-eks.yaml
@@ -138,7 +138,7 @@ alternateConfig:
     # Detect host and cloud metadata for hostname resolution and tagging
     resource_detection:
       detectors: [eks, ec2, env, system]
-      timeout: 2s
+      timeout: 15s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       eks:
         resource_attributes:

--- a/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset-gke-autopilot.yaml
@@ -98,7 +98,7 @@ alternateConfig:
   
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
-    resourcedetection:
+    resource_detection:
       detectors: [gcp, env, system]
       # If using older unsupported versions of GKE, you may need to supply the node name as `host.name` in `OTEL_RESOURCE_ATTRIBUTES`
       timeout: 2s
@@ -295,14 +295,14 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [otlp_http]
       
       metrics:
         receivers: [otlp, kubelet_stats]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
           - cumulativetodelta
           - deltatorate
         exporters: [otlp_http]
@@ -311,7 +311,7 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [forward/traces_sample, span_metrics]
       
       traces/sample:

--- a/configurations/opentelemetry-collector/helm-values/daemonset.yaml
+++ b/configurations/opentelemetry-collector/helm-values/daemonset.yaml
@@ -136,7 +136,7 @@ alternateConfig:
   
   processors:
     # Detect host and cloud metadata for hostname resolution and tagging
-    resourcedetection:
+    resource_detection:
       detectors: [env, system]
       timeout: 2s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -332,14 +332,14 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [otlp_http]
       
       metrics:
         receivers: [otlp, host_metrics, kubelet_stats]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
           - cumulativetodelta
           - deltatorate
         exporters: [otlp_http]
@@ -348,7 +348,7 @@ alternateConfig:
         receivers: [otlp]
         processors:
           - k8s_attributes
-          - resourcedetection
+          - resource_detection
         exporters: [forward/traces_sample, span_metrics]
       
       traces/sample:

--- a/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/helm-values/k8s-objects-datadog-eks.yaml
@@ -341,7 +341,7 @@ alternateConfig:
           - metric.name == "kube_service_spec_type"
     resourcedetection:
       detectors: [eks, ec2, env, kubeadm, system]
-      timeout: 2s
+      timeout: 15s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
       kubeadm:

--- a/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/k8s-objects-datadog-eks.yaml
@@ -273,7 +273,7 @@ processors:
         - metric.name == "kube_service_spec_type"
   resourcedetection:
     detectors: [eks, ec2, env, kubeadm, system]
-    timeout: 2s
+    timeout: 15s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
     # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
     kubeadm:

--- a/configurations/opentelemetry-collector/testing/agent-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/agent-datadog.yaml
@@ -49,7 +49,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -113,20 +113,20 @@ service:
     logs:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [datadog]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [datadog]
     
     traces:
       receivers: [otlp]
       processors:
-        - resourcedetection
+        - resource_detection
       exporters: [datadog/connector]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/daemonset-datadog.yaml
@@ -52,7 +52,7 @@ receivers:
 
 processors:
   # Detect host and cloud metadata for hostname resolution and tagging
-  resourcedetection:
+  resource_detection:
     detectors: [env, system]
     timeout: 2s
     override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -156,14 +156,14 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [datadog]
     
     metrics:
       receivers: [otlp, host_metrics]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
         - cumulativetodelta
       exporters: [datadog]
     
@@ -171,7 +171,7 @@ service:
       receivers: [otlp]
       processors:
         - k8s_attributes
-        - resourcedetection
+        - resource_detection
       exporters: [datadog/connector]
     
     traces/sample:

--- a/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/helm-k8s-objects-datadog-eks.yaml
@@ -342,7 +342,7 @@ alternateConfig:
           - metric.name == "kube_service_spec_type"
     resourcedetection:
       detectors: [eks, ec2, env, kubeadm, system]
-      timeout: 2s
+      timeout: 15s
       override: true # Disable if incoming attributes (especially host.name) are verified correct
       # kubeadm detector is required by the k8s_objects receiver to add k8s.cluster.uid into attributes
       kubeadm:

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
@@ -124,6 +124,9 @@ opentelemetry-collector:
       path: /
   
   alternateConfig:
+    # The EC2 and EKS resource detectors requires access to the IMDS endpoint from within a container,
+    # which requires setting the IMDS Token Hop Limit to 2 in either the node launch template or account settings.
+    
     receivers:
       # Receive telemetry from OpenTelemetry-instrumented applications
       otlp:
@@ -179,7 +182,7 @@ opentelemetry-collector:
     
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
-      resourcedetection:
+      resource_detection:
         detectors: [eks, ec2, env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -327,14 +330,14 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [datadog]
         
         metrics:
           receivers: [otlp, host_metrics, kubelet_stats]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [routing/metrics]
         
         metrics/cumul_sum_to_gauge:
@@ -356,7 +359,7 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [datadog/connector]
         
         traces/sample:

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog-eks.yaml
@@ -184,7 +184,7 @@ opentelemetry-collector:
       # Detect host and cloud metadata for hostname resolution and tagging
       resource_detection:
         detectors: [eks, ec2, env, system]
-        timeout: 2s
+        timeout: 15s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
         eks:
           resource_attributes:

--- a/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-datadog.yaml
@@ -182,7 +182,7 @@ opentelemetry-collector:
     
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
-      resourcedetection:
+      resource_detection:
         detectors: [env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -325,14 +325,14 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [datadog]
         
         metrics:
           receivers: [otlp, host_metrics, kubelet_stats]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [routing/metrics]
         
         metrics/cumul_sum_to_gauge:
@@ -354,7 +354,7 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [datadog/connector]
         
         traces/sample:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -176,7 +176,7 @@ opentelemetry-collector:
       # Detect host and cloud metadata for hostname resolution and tagging
       resource_detection:
         detectors: [eks, ec2, env, system]
-        timeout: 2s
+        timeout: 15s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
         eks:
           resource_attributes:

--- a/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo-eks.yaml
@@ -127,6 +127,9 @@ opentelemetry-collector:
       path: /
   
   alternateConfig:
+    # The EC2 and EKS resource detectors requires access to the IMDS endpoint from within a container,
+    # which requires setting the IMDS Token Hop Limit to 2 in either the node launch template or account settings.
+    
     receivers:
       # Receive telemetry from OpenTelemetry-instrumented applications
       otlp:
@@ -171,7 +174,7 @@ opentelemetry-collector:
     
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
-      resourcedetection:
+      resource_detection:
         detectors: [eks, ec2, env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -432,14 +435,14 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics:
           receivers: [otlp, host_metrics]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [routing/metrics]
         
         metrics/cumul_sum_to_gauge:
@@ -461,7 +464,7 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [forward/traces_sample, span_metrics]
         
         traces/sample:

--- a/configurations/opentelemetry-collector/testing/otel-demo.yaml
+++ b/configurations/opentelemetry-collector/testing/otel-demo.yaml
@@ -174,7 +174,7 @@ opentelemetry-collector:
     
     processors:
       # Detect host and cloud metadata for hostname resolution and tagging
-      resourcedetection:
+      resource_detection:
         detectors: [env, system]
         timeout: 2s
         override: true # Disable if incoming attributes (especially host.name) are verified correct
@@ -430,14 +430,14 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [otlp_http, otlp_http/dual_ship]
         
         metrics:
           receivers: [otlp, host_metrics]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [routing/metrics]
         
         metrics/cumul_sum_to_gauge:
@@ -459,7 +459,7 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
             - k8s_attributes
-            - resourcedetection
+            - resource_detection
           exporters: [forward/traces_sample, span_metrics]
         
         traces/sample:


### PR DESCRIPTION
### What does this PR do?

This PR:
- adds a config meant for EKS Auto Mode to the list of recommended configs, using only the EKS resource detector and with a note about additional required setup
- adds a similar note for the EKS (non-Auto) config
- renames the `resourcedetection` processor to `resource_detection`, since the old name is deprecated since v0.153.0 of the Collector, below our targeted version of v0.154.0, causing warnings on startup
