### PR TITLE
remove dual tags config

### DIFF
--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -51,8 +51,6 @@ spec:
         api:
           key: ${env:DD_API_KEY}
           site: ${env:DD_SITE:-datadoghq.com}
-        metrics:
-          resource_attributes_as_tags: true
         orchestrator_explorer:
           enabled: true
     extensions:
@@ -456,8 +454,6 @@ spec:
         api:
           key: ${env:DD_API_KEY}
           site: ${env:DD_SITE:-datadoghq.com}
-        metrics:
-          resource_attributes_as_tags: true
       debug: {}
     extensions:
       datadog:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -64,8 +64,6 @@ defaultCRConfig:
         api:
           key: ${env:DD_API_KEY}
           site: ${env:DD_SITE:-datadoghq.com}
-        metrics:
-          resource_attributes_as_tags: true
     extensions:
       health_check: {}
       datadog:


### PR DESCRIPTION
### What does this PR do?

This PR disables `resource_attributes_as_tags` in the Datadog exporter. It was enabled accidentally by the previous [PR](https://github.com/DataDog/opentelemetry-examples/pull/290).

Since this setting is not enabled in the existing Cluster or DaemonSet collectors, we should keep the behavior consistent.

- https://github.com/DataDog/opentelemetry-examples/blob/846663b168cfe41a1e39c7a71053eda2f9f78657/guides/kubernetes/configuration/daemonset-collector.yaml#L164-L168
- https://github.com/DataDog/opentelemetry-examples/blob/846663b168cfe41a1e39c7a71053eda2f9f78657/guides/kubernetes/configuration/cluster-collector.yaml#L240-L246

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
