### PR TITLE
Kubernetes count collector updates

### DIFF
--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -49,7 +49,7 @@ config:
                   - kube-state-metrics.default.svc:8080
             metric_relabel_configs:
               - source_labels: [__name__]
-                regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
+                regex: "kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                 action: keep
 
   processors:
@@ -154,6 +154,9 @@ config:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
 
     # Drop metrics after count connector has used them
     filter/ksm:
@@ -161,6 +164,9 @@ config:
         metric:
           - metric.name == "kube_service_spec_type"
           - metric.name == "kube_namespace_created"
+          - metric.name == "kube_statefulset_created"
+          - metric.name == "kube_daemonset_created"
+
 
     # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (k8s_api).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
@@ -190,7 +196,7 @@ config:
     #       action: upsert
 
   connectors:
-    # The count connector helps us generate six custom metrics by counting the number
+    # The count connector helps us generate nine custom metrics by counting the number
     # of metric series. It generates the following metrics:
     # 1. k8s.service.count
     # 2. k8s.node.count
@@ -198,6 +204,9 @@ config:
     # 4. k8s.deployment.count
     # 5. k8s.pod.count
     # 6. k8s.namespace.count
+    # 7. k8s.statefulset.count
+    # 8. k8s.daemonset.count
+    # 9. k8s.cronjob.count
     count:
       datapoints:
         k8s.service.count:
@@ -216,6 +225,9 @@ config:
             - metric.name == "kube_node_info"
 
         k8s.job.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
           conditions:
             - metric.name == "kube_job_owner"
 
@@ -236,6 +248,27 @@ config:
         k8s.namespace.count:
           conditions:
             - metric.name == "kube_namespace_created"
+
+        k8s.statefulset.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
+          conditions:
+            - metric.name == "kube_statefulset_created"
+
+        k8s.daemonset.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
+          conditions:
+            - metric.name == "kube_daemonset_created"
+
+        k8s.cronjob.count:
+          attributes:
+            - key: namespace
+              default_value: unspecified_namespace
+          conditions:
+            - metric.name == "kube_cronjob_info"
 
   exporters:
     datadog/exporter:

--- a/guides/kubernetes/configuration/cluster-collector.yaml
+++ b/guides/kubernetes/configuration/cluster-collector.yaml
@@ -114,6 +114,10 @@ config:
             - set(attributes["kube_service"], attributes["service"])
             - delete_key(attributes, "service")
 
+            # cronjob
+            - set(attributes["kube_cronjob"], attributes["cronjob"])
+            - delete_key(attributes, "cronjob")
+
     # k8s_attributesprocessor is used to enrich metrics with additional metadata, namely, service.
     k8s_attributes:
       auth_type: "serviceAccount"
@@ -157,16 +161,6 @@ config:
         - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
         - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
         - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
-
-    # Drop metrics after count connector has used them
-    filter/ksm:
-      metrics:
-        metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
-          - metric.name == "kube_statefulset_created"
-          - metric.name == "kube_daemonset_created"
-
 
     # Detects k8s.cluster.name (gcp, eks, aks) and k8s.cluster.uid (k8s_api).
     # Adjust the k8s.cluster.name settings below for your cloud provider.
@@ -293,7 +287,6 @@ config:
         receivers: [otlp, prometheus, count]
         processors:
           [
-            filter/ksm,
             resourcedetection,
             transform/ksm_to_dd,
             transform/rename_uid,

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ rules:
   resources:
   - namespaces
   - nodes
-  - nodes/pods
+  - nodes/proxy
   - nodes/metrics
   - nodes/stats
   - services

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -17,6 +17,18 @@ spec:
     connectors:
       count/k8s_entities:
         datapoints:
+          k8s.cronjob.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_cronjob_info"
+          k8s.daemonset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_daemonset_created"
           k8s.deployment.count:
             attributes:
             - default_value: unspecified_namespace
@@ -24,6 +36,9 @@ spec:
             conditions:
             - metric.name == "kube_deployment_created"
           k8s.job.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
             conditions:
             - metric.name == "kube_job_owner"
           k8s.namespace.count:
@@ -46,6 +61,12 @@ spec:
               key: type
             conditions:
             - metric.name == "kube_service_spec_type"
+          k8s.statefulset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_statefulset_created"
     exporters:
       datadog/exporter:
         api:
@@ -66,11 +87,6 @@ spec:
         lease_namespace: opentelemetry-operator-system
     processors:
       cumulativetodelta: {}
-      filter/ksm:
-        metrics:
-          metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
       groupbyattrs:
         keys:
         - k8s.pod.uid
@@ -153,6 +169,8 @@ spec:
           - delete_key(attributes, "job_name")
           - set(attributes["kube_service"], attributes["service"])
           - delete_key(attributes, "service")
+          - set(attributes["kube_cronjob"], attributes["cronjob"])
+          - delete_key(attributes, "cronjob")
       transform/rename_uid:
         metric_statements:
         - context: datapoint
@@ -171,6 +189,9 @@ spec:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
     receivers:
       k8s_cluster:
         allocatable_types_to_report:
@@ -324,7 +345,7 @@ spec:
           - job_name: kube-state-metrics
             metric_relabel_configs:
             - action: keep
-              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              regex: kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
               source_labels:
               - __name__
             metrics_path: /metrics
@@ -350,7 +371,6 @@ spec:
           exporters:
           - datadog/exporter
           processors:
-          - filter/ksm
           - transform/ksm_to_dd
           - transform/rename_uid
           - groupbyattrs

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -165,7 +165,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - nodes/pods
+      - nodes/proxy
     verbs:
       - get
   - apiGroups:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -116,7 +116,7 @@ collectors:
                       - kube-state-metrics:8080
                 metric_relabel_configs:
                   - source_labels: [__name__]
-                    regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
+                    regex: "kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                     action: keep
 
       processors:
@@ -159,6 +159,8 @@ collectors:
                 - delete_key(attributes, "job_name")
                 - set(attributes["kube_service"], attributes["service"])
                 - delete_key(attributes, "service")
+                - set(attributes["kube_cronjob"], attributes["cronjob"])
+                - delete_key(attributes, "cronjob")
 
         # Pin pod_association to k8s.pod.uid so KSM metrics are associated
         # with their target pod (uid set by transform/rename_uid), not the
@@ -177,13 +179,9 @@ collectors:
             - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
             - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
             - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
-
-        # Drop KSM series once the count connector has consumed them.
-        filter/ksm:
-          metrics:
-            metric:
-              - metric.name == "kube_service_spec_type"
-              - metric.name == "kube_namespace_created"
+            - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+            - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+            - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
 
       connectors:
         count/k8s_entities:
@@ -211,6 +209,24 @@ collectors:
               conditions: [metric.name == "kube_pod_info"]
             k8s.namespace.count:
               conditions: [metric.name == "kube_namespace_created"]
+            k8s.statefulset.count:
+              attributes:
+                - key: namespace
+                  default_value: unspecified_namespace
+              conditions:
+                - metric.name == "kube_statefulset_created"
+            k8s.daemonset.count:
+              attributes:
+                - key: namespace
+                  default_value: unspecified_namespace
+              conditions:
+                - metric.name == "kube_daemonset_created"
+            k8s.cronjob.count:
+              attributes:
+                - key: namespace
+                  default_value: unspecified_namespace
+              conditions:
+                - metric.name == "kube_cronjob_info"
 
       exporters:
         datadog/exporter:
@@ -231,7 +247,6 @@ collectors:
           metrics:
             receivers: [otlp, prometheus/ksm, count/k8s_entities]
             processors:
-              - filter/ksm
               - transform/ksm_to_dd
               - transform/rename_uid
               - groupbyattrs

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -196,6 +196,9 @@ collectors:
             k8s.node.count:
               conditions: [metric.name == "kube_node_info"]
             k8s.job.count:
+              attributes:
+                - key: namespace
+                  default_value: unspecified_namespace
               conditions: [metric.name == "kube_job_owner"]
             k8s.deployment.count:
               attributes:


### PR DESCRIPTION
### What does this PR do?
#### Primary Purpose
Adds additional `.count` metrics to the collector to count cronjobs, statefulsets, and daemonsets.

#### Cleanup
No longer filters any KSM metrics that are used in the count pipeline. This is an optimization not worth cluttering the config with.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Further metric parity between OTel collector and DD


### Evidence
I deployed a collector with the new config and can observe the new metrics.

<img width="1507" height="766" alt="Screenshot 2026-08-14 at 10 52 03 AM" src="https://github.com/user-attachments/assets/4bc8b448-c62b-49bc-b5fe-96bcf5e970e4" />

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
