### PR TITLE
Scrape OTel Operator internal metrics from the `cluster` collector

### DIFF
--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -137,7 +137,8 @@ The `cluster` collector scrapes the operator manager's own Prometheus metrics vi
 receiver (`values.yaml`, `collectors.cluster.config.receivers`).
 
 As of v0.154.0 of the OpenTelemetry Operator, like any [controller-runtime][controller-runtime]-based operator, the
-manager exposes the standard controller-runtime metrics registry on its `--metrics-bind-address` (secured with
+manager exposes the standard controller-runtime metrics registry (documented in the
+[Kubebuilder metrics reference][kubebuilder-metrics]) on its `--metrics-bind-address` (secured with
 `--metrics-secure`, port `8443` by default in this Helm chart, fronted by kube-rbac-proxy). These are generic reconciler
 metrics, not anything OTel-specific — the same set any Kubebuilder/controller-runtime operator emits:
 
@@ -170,4 +171,5 @@ metrics, not anything OTel-specific — the same set any Kubebuilder/controller-
 The receiver uses the Collector pod's own ServiceAccount token to authenticate against the kube-rbac-proxy.
 
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+[kubebuilder-metrics]: https://book.kubebuilder.io/reference/metrics-reference
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -128,3 +128,118 @@ Verified against:
 
 [chart]: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack
 [cm]: https://cert-manager.io/docs/installation/
+
+## Appendix
+
+### OpenTelemetry Operator Internal Metrics
+
+The `cluster` collector scrapes the operator manager's own Prometheus metrics via the `prometheus/otel_operator`
+receiver (`values.yaml`, `collectors.cluster.config.receivers`).
+
+Like any [controller-runtime][controller-runtime]-based operator, the manager exposes the standard controller-runtime
+metrics registry on its `--metrics-bind-address` (secured with `--metrics-secure`, port `8443` by default in this
+Helm chart, fronted by kube-rbac-proxy). These are generic reconciler metrics, not anything OTel-specific — the same
+set any Kubebuilder/controller-runtime operator emits:
+
+- `controller_runtime_reconcile_total`, `controller_runtime_reconcile_errors_total`,
+  `controller_runtime_reconcile_time_seconds` — reconcile loop counts, errors, and latency, per controller. A
+  *reconciliation* is one run of a controller's control loop: whenever a watched resource (e.g. an
+  `OpenTelemetryCollector` or `Instrumentation` custom resource, or a `Pod` the operator injects into) is created,
+  updated, or deleted, the controller is asked to look at that object's current state and drive the cluster's actual
+  state toward the desired state described in the resource spec — creating/updating the Deployment, ConfigMap,
+  webhooks, etc. it owns. Reconciliations are also re-run periodically and after transient errors, so these metrics
+  are the best signal for whether the operator is keeping up and succeeding.
+- `workqueue_depth`, `workqueue_adds_total`, `workqueue_queue_duration_seconds`,
+  `workqueue_work_duration_seconds` — health of each controller's *work queue*. Each controller has a work queue that
+  decouples "an object changed" (an event from the informer/watch cache) from "process that object" (a
+  reconciliation): watch events enqueue the object's key, and a pool of workers dequeues keys one at a time and runs
+  the reconcile function for each. This queue also deduplicates rapid-fire updates to the same object and provides
+  retry-with-backoff by re-enqueueing keys whose reconciliation failed. `workqueue_depth` is the number of items
+  waiting to be processed (a sustained rise means the operator can't keep up), `workqueue_queue_duration_seconds` is
+  how long items wait before a worker picks them up, and `workqueue_work_duration_seconds` is how long the actual
+  reconcile takes once dequeued.
+- `controller_runtime_active_workers` — number of reconcile workers currently running per controller.
+- `controller_runtime_webhook_requests_total`, `controller_runtime_webhook_requests_in_flight`,
+  `controller_runtime_webhook_latency_seconds` — count, concurrency, and latency of admission webhook calls, labeled
+  by `webhook` path (e.g. the pod-mutating webhook that injects instrumentation, and the validating/mutating webhooks
+  for the `OpenTelemetryCollector`/`Instrumentation` CRs). Distinct from the reconcile metrics above: webhooks run
+  synchronously inside the Kubernetes API request path (at `Pod`/CR admission time), while reconciliation runs
+  asynchronously afterwards.
+- Standard Go/process runtime metrics (`go_*`, `process_*`).
+
+Because the endpoint is protected by kube-rbac-proxy, scraping requires HTTPS and a bearer token; the receiver uses
+the collector pod's own ServiceAccount token
+(`/var/run/secrets/kubernetes.io/serviceaccount/token`), which the chart's `ClusterRole` already authorizes for the
+`/metrics` non-resource URL.
+
+### Detecting instrumentation-injection and collector-creation problems
+
+The operator drives two distinct workloads through two distinct code paths, and each fails and gets observed
+differently:
+
+- **Instrumentation injection** happens synchronously in the pod-mutating admission **webhook**: when a `Pod` is
+  created in a namespace/with annotations selected by an `Instrumentation` resource, the API server calls the
+  operator's webhook to inject the init container and env vars before the pod is persisted. There is no reconcile
+  loop or work queue involved.
+- **Collector creation/update** (and any other CR the operator owns, e.g. `Instrumentation` itself) happens
+  asynchronously through the **reconcile loop**: a change to an `OpenTelemetryCollector` CR enqueues a work item,
+  and a worker later reconciles it into a `Deployment`/`DaemonSet`/`StatefulSet`, `ConfigMap`, `Service`, RBAC, etc.
+
+#### Scenario: workloads aren't getting instrumentation injected
+
+Symptoms: a pod that should have an auto-instrumentation init container doesn't get one (no
+`opentelemetry-auto-instrumentation-*` init container, no `OTEL_*` env vars), even though its `Instrumentation`
+resource and pod annotations look correct.
+
+- Check `controller_runtime_webhook_requests_total` for the pod-mutating webhook path, split by response code.
+  `5xx`/rejected admissions there mean the webhook is erroring on incoming pods — check the operator manager logs for
+  the reason (e.g. malformed `Instrumentation` spec, unsupported language runtime, image pull/config issues baked
+  into the webhook logic).
+- If this metric shows **no requests at all** for pods you expect to be mutated, the API server likely isn't calling
+  the webhook: check the `MutatingWebhookConfiguration` (`failurePolicy`, `namespaceSelector`/`objectSelector`,
+  `caBundle`), and that the webhook `Service`/endpoint and its TLS certificate (issued via [cert-manager][cm] in this
+  chart) are healthy — an expired or mismatched cert makes the API server skip or fail the webhook call depending on
+  `failurePolicy` (`Ignore` silently skips injection; `Fail` blocks pod creation entirely).
+- `controller_runtime_webhook_latency_seconds` climbing indicates slow admission calls, which can cause pod creation
+  timeouts and, depending on `failurePolicy`, either dropped instrumentation (`Ignore`) or blocked deployments
+  (`Fail`).
+
+#### Scenario: `OpenTelemetryCollector` resources aren't producing running collectors
+
+Symptoms: applying/updating an `OpenTelemetryCollector` CR doesn't create or update the expected `Deployment`/
+`DaemonSet`/`StatefulSet` and its config, or changes take unexpectedly long to appear.
+
+- Check `controller_runtime_reconcile_errors_total` for the collector controller — a rising counter means
+  reconciliations are failing (e.g. RBAC denial creating owned objects, resource quota exceeded, invalid rendered
+  collector config). Cross-reference with `kubectl describe opentelemetrycollector <name>` (status/conditions) and
+  the operator manager's logs, which log the reconcile error.
+- Compare `controller_runtime_reconcile_total` against the number of CR create/update events you'd expect — an
+  absence of reconciles for a changed CR suggests the watch/informer isn't picking up the change (e.g. label/field
+  selector mismatch, or the manager pod itself is down/crash-looping — check its readiness via `health_check`).
+
+#### Scenario: the operator is saturated, causing delayed injection or collector reconciliation
+
+Symptoms: instrumentation injection and/or collector reconciliation still eventually succeed, but noticeably later
+than the triggering pod/CR change — a sign the manager can't keep up with the rate of incoming work.
+
+- `workqueue_depth` sustained above zero and trending up means reconciles are being enqueued faster than workers can
+  drain them.
+- `workqueue_queue_duration_seconds` rising is the direct measure of this delay — how long a reconcile waits in the
+  queue before a worker starts on it. This is the metric most directly tied to "why did my collector change take
+  minutes to apply."
+- `controller_runtime_active_workers` pegged at its configured max (`--max-concurrent-reconciles`, chart default
+  unless overridden) alongside a growing `workqueue_depth` confirms the worker pool, not something external, is the
+  bottleneck.
+- `controller_runtime_webhook_requests_in_flight` staying elevated, together with rising
+  `controller_runtime_webhook_latency_seconds`, indicates the same saturation is also slowing pod admission —
+  because the webhook and the reconcilers share the same manager process and CPU/memory allocation
+  (`opentelemetry-operator.manager` resources in `values.yaml`).
+- Correlate with the manager pod's own CPU/memory usage (from `process_cpu_seconds_total`, `process_resident_memory_bytes`,
+  or the pod's cgroup metrics) and with `controller_runtime_reconcile_time_seconds` to see whether reconciles
+  themselves are getting slower (e.g. slow Kubernetes API server) versus just queueing longer (too much work, too few
+  workers). The fix is typically to raise the manager's CPU/memory requests/limits or its
+  `--max-concurrent-reconciles`, since (unlike the collectors) this chart deploys a single operator manager
+  replica (leader-elected, so extra replicas are standby only, not extra throughput).
+
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -215,7 +215,9 @@ Symptoms: applying/updating an `OpenTelemetryCollector` CR doesn't create or upd
   the operator manager's logs, which log the reconcile error.
 - Compare `controller_runtime_reconcile_total` against the number of CR create/update events you'd expect — an
   absence of reconciles for a changed CR suggests the watch/informer isn't picking up the change (e.g. label/field
-  selector mismatch, or the manager pod itself is down/crash-looping — check its readiness via `health_check`).
+  selector mismatch, or the manager pod itself is down/crash-looping — check its `Pod` readiness condition, or query
+  its `/readyz` (readiness) and `/healthz` (liveness) endpoints directly, both served on port `8081`
+  (`--health-probe-addr`, see the rendered manager `Deployment`'s probes).
 
 #### Scenario: the operator is saturated, causing delayed injection or collector reconciliation
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -139,8 +139,8 @@ receiver (`values.yaml`, `collectors.cluster.config.receivers`).
 As of v0.154.0 of the OpenTelemetry Operator, like any [controller-runtime][controller-runtime]-based operator, the
 manager exposes the standard controller-runtime metrics registry (documented in the
 [Kubebuilder metrics reference][kubebuilder-metrics]) on its `--metrics-bind-address` (secured with
-`--metrics-secure`, port `8443` by default in this Helm chart, fronted by kube-rbac-proxy). These are generic reconciler
-metrics, not anything OTel-specific — the same set any Kubebuilder/controller-runtime operator emits:
+`--metrics-secure`, port `8443` by default in this Helm chart, fronted by [kube-rbac-proxy][kube-rbac-proxy]). These are
+generic reconciler metrics, not anything OTel-specific — the same set any Kubebuilder/controller-runtime operator emits:
 
 - `controller_runtime_reconcile_total`, `controller_runtime_reconcile_errors_total`,
   `controller_runtime_reconcile_time_seconds` — reconcile loop counts, errors, and latency, per controller. A
@@ -168,8 +168,17 @@ metrics, not anything OTel-specific — the same set any Kubebuilder/controller-
   asynchronously afterwards.
 - Standard Go/process runtime metrics (`go_*`, `process_*`).
 
-The receiver uses the Collector pod's own ServiceAccount token to authenticate against the kube-rbac-proxy.
+kube-rbac-proxy sits in front of the metrics endpoint and, for any HTTP client to be let through, requires an
+`Authorization: Bearer <token>` header over TLS — it forwards the token to the Kubernetes API server's
+TokenReview/SubjectAccessReview endpoints to authenticate the caller and authorize the request (see
+[kube-rbac-proxy's authentication/authorization docs][kube-rbac-proxy-auth]). The `prometheus/otel_operator` scrape
+config (`values.yaml`, `collectors.cluster.config.receivers`) satisfies this by setting `scheme: https`,
+`bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token` (the Collector pod's own ServiceAccount
+token, mounted automatically), and `tls_config.insecure_skip_verify: true` since kube-rbac-proxy's default
+self-signed serving certificate isn't in the scraper's trust store.
 
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
 [kubebuilder-metrics]: https://book.kubebuilder.io/reference/metrics-reference
+[kube-rbac-proxy]: https://github.com/brancz/kube-rbac-proxy
+[kube-rbac-proxy-auth]: https://github.com/brancz/kube-rbac-proxy#authentication--authorization
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -167,10 +167,7 @@ set any Kubebuilder/controller-runtime operator emits:
   asynchronously afterwards.
 - Standard Go/process runtime metrics (`go_*`, `process_*`).
 
-Because the endpoint is protected by kube-rbac-proxy, scraping requires HTTPS and a bearer token; the receiver uses
-the collector pod's own ServiceAccount token
-(`/var/run/secrets/kubernetes.io/serviceaccount/token`), which the chart's `ClusterRole` already authorizes for the
-`/metrics` non-resource URL.
+The receiver uses the Collector pod's own ServiceAccount token to authenticate against the kube-rbac-proxy.
 
 ### Detecting instrumentation-injection and collector-creation problems
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -136,10 +136,10 @@ Verified against:
 The `cluster` collector scrapes the operator manager's own Prometheus metrics via the `prometheus/otel_operator`
 receiver (`values.yaml`, `collectors.cluster.config.receivers`).
 
-Like any [controller-runtime][controller-runtime]-based operator, the manager exposes the standard controller-runtime
-metrics registry on its `--metrics-bind-address` (secured with `--metrics-secure`, port `8443` by default in this
-Helm chart, fronted by kube-rbac-proxy). These are generic reconciler metrics, not anything OTel-specific — the same
-set any Kubebuilder/controller-runtime operator emits:
+As of v0.154.0 of the OpenTelemetry Operator, like any [controller-runtime][controller-runtime]-based operator, the
+manager exposes the standard controller-runtime metrics registry on its `--metrics-bind-address` (secured with
+`--metrics-secure`, port `8443` by default in this Helm chart, fronted by kube-rbac-proxy). These are generic reconciler
+metrics, not anything OTel-specific — the same set any Kubebuilder/controller-runtime operator emits:
 
 - `controller_runtime_reconcile_total`, `controller_runtime_reconcile_errors_total`,
   `controller_runtime_reconcile_time_seconds` — reconcile loop counts, errors, and latency, per controller. A
@@ -168,80 +168,6 @@ set any Kubebuilder/controller-runtime operator emits:
 - Standard Go/process runtime metrics (`go_*`, `process_*`).
 
 The receiver uses the Collector pod's own ServiceAccount token to authenticate against the kube-rbac-proxy.
-
-### Detecting instrumentation-injection and collector-creation problems
-
-The operator drives two distinct workloads through two distinct code paths, and each fails and gets observed
-differently:
-
-- **Instrumentation injection** happens synchronously in the pod-mutating admission **webhook**: when a `Pod` is
-  created in a namespace/with annotations selected by an `Instrumentation` resource, the API server calls the
-  operator's webhook to inject the init container and env vars before the pod is persisted. There is no reconcile
-  loop or work queue involved.
-- **Collector creation/update** (and any other CR the operator owns, e.g. `Instrumentation` itself) happens
-  asynchronously through the **reconcile loop**: a change to an `OpenTelemetryCollector` CR enqueues a work item,
-  and a worker later reconciles it into a `Deployment`/`DaemonSet`/`StatefulSet`, `ConfigMap`, `Service`, RBAC, etc.
-
-#### Scenario: workloads aren't getting instrumentation injected
-
-Symptoms: a pod that should have an auto-instrumentation init container doesn't get one (no
-`opentelemetry-auto-instrumentation-*` init container, no `OTEL_*` env vars), even though its `Instrumentation`
-resource and pod annotations look correct.
-
-- Check `controller_runtime_webhook_requests_total` for the pod-mutating webhook path, split by response code.
-  `5xx`/rejected admissions there mean the webhook is erroring on incoming pods — check the operator manager logs for
-  the reason (e.g. malformed `Instrumentation` spec, unsupported language runtime, image pull/config issues baked
-  into the webhook logic).
-- If this metric shows **no requests at all** for pods you expect to be mutated, the API server likely isn't calling
-  the webhook: check the `MutatingWebhookConfiguration` (`failurePolicy`, `namespaceSelector`/`objectSelector`,
-  `caBundle`), and that the webhook `Service`/endpoint and its TLS certificate (issued via [cert-manager][cm] in this
-  chart) are healthy — an expired or mismatched cert makes the API server skip or fail the webhook call depending on
-  `failurePolicy` (`Ignore` silently skips injection; `Fail` blocks pod creation entirely).
-- `controller_runtime_webhook_latency_seconds` climbing indicates slow admission calls, which can cause pod creation
-  timeouts and, depending on `failurePolicy`, either dropped instrumentation (`Ignore`) or blocked deployments
-  (`Fail`).
-
-#### Scenario: `OpenTelemetryCollector` resources aren't producing running collectors
-
-Symptoms: applying/updating an `OpenTelemetryCollector` CR doesn't create or update the expected `Deployment`/
-`DaemonSet`/`StatefulSet` and its config, or changes take unexpectedly long to appear.
-
-- Check `controller_runtime_reconcile_errors_total` for the collector controller — a rising counter means
-  reconciliations are failing (e.g. RBAC denial creating owned objects, resource quota exceeded, invalid rendered
-  collector config). Cross-reference with `kubectl describe opentelemetrycollector <name>` (status/conditions) and
-  the operator manager's logs, which log the reconcile error.
-- Compare `controller_runtime_reconcile_total` against the number of CR create/update events you'd expect — an
-  absence of reconciles for a changed CR suggests the watch/informer isn't picking up the change (e.g. label/field
-  selector mismatch, or the manager pod itself is down/crash-looping — check its `Pod` readiness condition, or query
-  its `/readyz` (readiness) and `/healthz` (liveness) endpoints directly, both served on port `8081`
-  (`--health-probe-addr`, see the rendered manager `Deployment`'s probes).
-
-#### Scenario: the operator is saturated, causing delayed injection or collector reconciliation
-
-Symptoms: instrumentation injection and/or collector reconciliation still eventually succeed, but noticeably later
-than the triggering pod/CR change — a sign the manager can't keep up with the rate of incoming work.
-
-- `workqueue_depth` sustained above zero and trending up means reconciles are being enqueued faster than workers can
-  drain them.
-- `workqueue_queue_duration_seconds` rising is the direct measure of this delay — how long a reconcile waits in the
-  queue before a worker starts on it. This is the metric most directly tied to "why did my collector change take
-  minutes to apply."
-- `controller_runtime_active_workers` pegged at its configured max (`--max-concurrent-reconciles`, chart default
-  unless overridden) alongside a growing `workqueue_depth` confirms the worker pool, not something external, is the
-  bottleneck.
-- `controller_runtime_webhook_requests_in_flight` staying elevated, together with rising
-  `controller_runtime_webhook_latency_seconds`, indicates the same saturation is also slowing pod admission —
-  because the webhook and the reconcilers share the same manager process and CPU/memory allocation
-  (`opentelemetry-operator.manager` resources in `values.yaml`).
-- Correlate with the manager pod's own CPU/memory usage (from `process_cpu_seconds_total`, `process_resident_memory_bytes`,
-  or the pod's cgroup metrics) and with `controller_runtime_reconcile_time_seconds` to see whether reconciles
-  themselves are getting slower (e.g. slow Kubernetes API server) versus just queueing longer (too much work, too few
-  workers). The fix depends on which side is saturated: reconcile/work-queue backlogs are addressed by raising the
-  manager's CPU/memory requests/limits or its `--max-concurrent-reconciles` — reconciliation is leader-elected, so
-  only the active leader processes the work queue and extra replicas don't add reconcile throughput. Delayed pod
-  admission (elevated webhook in-flight/latency) is different: the webhook server runs in every replica regardless
-  of leader status, so scaling `opentelemetry-operator.replicaCount` up (this chart defaults to a single replica)
-  does add webhook/admission throughput, in addition to raising CPU/memory.
 
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -239,9 +239,12 @@ than the triggering pod/CR change — a sign the manager can't keep up with the 
 - Correlate with the manager pod's own CPU/memory usage (from `process_cpu_seconds_total`, `process_resident_memory_bytes`,
   or the pod's cgroup metrics) and with `controller_runtime_reconcile_time_seconds` to see whether reconciles
   themselves are getting slower (e.g. slow Kubernetes API server) versus just queueing longer (too much work, too few
-  workers). The fix is typically to raise the manager's CPU/memory requests/limits or its
-  `--max-concurrent-reconciles`, since (unlike the collectors) this chart deploys a single operator manager
-  replica (leader-elected, so extra replicas are standby only, not extra throughput).
+  workers). The fix depends on which side is saturated: reconcile/work-queue backlogs are addressed by raising the
+  manager's CPU/memory requests/limits or its `--max-concurrent-reconciles` — reconciliation is leader-elected, so
+  only the active leader processes the work queue and extra replicas don't add reconcile throughput. Delayed pod
+  admission (elevated webhook in-flight/latency) is different: the webhook server runs in every replica regardless
+  of leader status, so scaling `opentelemetry-operator.replicaCount` up (this chart defaults to a single replica)
+  does add webhook/admission throughput, in addition to raising CPU/memory.
 
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -144,8 +144,8 @@ set any Kubebuilder/controller-runtime operator emits:
 - `controller_runtime_reconcile_total`, `controller_runtime_reconcile_errors_total`,
   `controller_runtime_reconcile_time_seconds` — reconcile loop counts, errors, and latency, per controller. A
   *reconciliation* is one run of a controller's control loop: whenever a watched resource (e.g. an
-  `OpenTelemetryCollector` or `Instrumentation` custom resource, or a `Pod` the operator injects into) is created,
-  updated, or deleted, the controller is asked to look at that object's current state and drive the cluster's actual
+  `OpenTelemetryCollector` or `Instrumentation` custom resource) is created, updated, or deleted, the controller is
+  asked to look at that object's current state and drive the cluster's actual
   state toward the desired state described in the resource spec — creating/updating the Deployment, ConfigMap,
   webhooks, etc. it owns. Reconciliations are also re-run periodically and after transient errors, so these metrics
   are the best signal for whether the operator is keeping up and succeeding.

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
@@ -335,6 +335,18 @@ spec:
             static_configs:
             - targets:
               - kube-state-metrics:8080
+      prometheus/otel_operator:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: opentelemetry-operator
+            metrics_path: /metrics
+            scheme: https
+            static_configs:
+            - targets:
+              - opentelemetry-kube-stack-opentelemetry-operator:8443
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -373,6 +385,15 @@ spec:
           - count/k8s_entities
           receivers:
           - prometheus/ksm
+        metrics/otel_operator:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - cumulativetodelta
+          receivers:
+          - prometheus/otel_operator
       telemetry:
         metrics:
           readers:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -330,6 +330,18 @@ spec:
             static_configs:
             - targets:
               - kube-state-metrics:8080
+      prometheus/otel_operator:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: opentelemetry-operator
+            metrics_path: /metrics
+            scheme: https
+            static_configs:
+            - targets:
+              - opentelemetry-kube-stack-opentelemetry-operator:8443
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -368,6 +380,15 @@ spec:
           - count/k8s_entities
           receivers:
           - prometheus/ksm
+        metrics/otel_operator:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - cumulativetodelta
+          receivers:
+          - prometheus/otel_operator
       telemetry:
         metrics:
           readers:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
@@ -336,6 +336,18 @@ spec:
             static_configs:
             - targets:
               - kube-state-metrics:8080
+      prometheus/otel_operator:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: opentelemetry-operator
+            metrics_path: /metrics
+            scheme: https
+            static_configs:
+            - targets:
+              - opentelemetry-kube-stack-opentelemetry-operator:8443
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -374,6 +386,15 @@ spec:
           - count/k8s_entities
           receivers:
           - prometheus/ksm
+        metrics/otel_operator:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - cumulativetodelta
+          receivers:
+          - prometheus/otel_operator
       telemetry:
         metrics:
           readers:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
@@ -335,6 +335,18 @@ spec:
             static_configs:
             - targets:
               - kube-state-metrics:8080
+      prometheus/otel_operator:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: opentelemetry-operator
+            metrics_path: /metrics
+            scheme: https
+            static_configs:
+            - targets:
+              - opentelemetry-kube-stack-opentelemetry-operator:8443
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -373,6 +385,15 @@ spec:
           - count/k8s_entities
           receivers:
           - prometheus/ksm
+        metrics/otel_operator:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - cumulativetodelta
+          receivers:
+          - prometheus/otel_operator
       telemetry:
         metrics:
           readers:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
@@ -330,6 +330,18 @@ spec:
             static_configs:
             - targets:
               - kube-state-metrics:8080
+      prometheus/otel_operator:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: opentelemetry-operator
+            metrics_path: /metrics
+            scheme: https
+            static_configs:
+            - targets:
+              - opentelemetry-kube-stack-opentelemetry-operator:8443
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -368,6 +380,15 @@ spec:
           - count/k8s_entities
           receivers:
           - prometheus/ksm
+        metrics/otel_operator:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - cumulativetodelta
+          receivers:
+          - prometheus/otel_operator
       telemetry:
         metrics:
           readers:
@@ -420,12 +441,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=my_k8s_cluster"
   
-  - name: DD_SITE
-    valueFrom:
-      secretKeyRef:
-        key: dd-site
-        name: datadog-secret
-        optional: true
   - name: OTEL_K8S_CLUSTER_NAME
     value: "my_k8s_cluster"
   - name: DD_API_KEY
@@ -433,6 +448,12 @@ spec:
       secretKeyRef:
         key: api-key
         name: datadog-secret
+  - name: DD_SITE
+    valueFrom:
+      secretKeyRef:
+        key: dd-site
+        name: datadog-secret
+        optional: true
 ---
 # Source: opentelemetry-kube-stack/templates/collector.yaml
 apiVersion: opentelemetry.io/v1beta1
@@ -773,12 +794,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=my_k8s_cluster"
   
-  - name: DD_SITE
-    valueFrom:
-      secretKeyRef:
-        key: dd-site
-        name: datadog-secret
-        optional: true
   - name: OTEL_K8S_CLUSTER_NAME
     value: "my_k8s_cluster"
   - name: DD_API_KEY
@@ -786,6 +801,12 @@ spec:
       secretKeyRef:
         key: api-key
         name: datadog-secret
+  - name: DD_SITE
+    valueFrom:
+      secretKeyRef:
+        key: dd-site
+        name: datadog-secret
+        optional: true
   volumes:
   - name: varlogpods
     hostPath:
@@ -796,3 +817,4 @@ spec:
   - name: hostfs
     hostPath:
       path: /
+

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -142,6 +142,19 @@ collectors:
                     regex: "kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type"
                     action: keep
 
+        prometheus/otel_operator:
+          config:
+            scrape_configs:
+              - job_name: "opentelemetry-operator"
+                metrics_path: /metrics
+                scheme: https
+                tls_config:
+                  insecure_skip_verify: true
+                bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                static_configs:
+                  - targets:
+                      - opentelemetry-kube-stack-opentelemetry-operator:8443
+
       processors:
         # Rename the prometheus `uid` label to k8s.pod.uid (OTel standard),
         # required for the groupbyattrs step below.
@@ -245,6 +258,14 @@ collectors:
           logs:
             receivers: [k8s_objects]
             processors: [resource_detection/env, transform/insert_k8s_cluster_name]
+            exporters: [datadog/exporter]
+
+          metrics/otel_operator:
+            receivers: [prometheus/otel_operator]
+            processors:
+              - resource_detection/env
+              - transform/insert_k8s_cluster_name
+              - cumulativetodelta
             exporters: [datadog/exporter]
 
           metrics/count:


### PR DESCRIPTION
Add a Prometheus scrape of the OpenTelemetry Operator manager's own metrics
(`prometheus/otel_operator` receiver) to the `cluster` collector in the
`opentelemetry-kube-stack` guide, alongside the existing kube-state-metrics
scrape.

- New `prometheus/otel_operator` receiver scrapes
  `opentelemetry-kube-stack-opentelemetry-operator:8443` over HTTPS, using the
  collector pod's own ServiceAccount bearer token and skipping TLS
  verification (self-signed cert behind kube-rbac-proxy). No RBAC changes
  needed — the chart's `ClusterRole` already grants the `/metrics`
  non-resource URL to the collector's ServiceAccount.
- New `metrics/otel_operator` pipeline routes this receiver through the
  shared `resource_detection/env` / `transform/insert_k8s_cluster_name` /
  `cumulativetodelta` processors to the Datadog exporter.
- Re-rendered all `examples/*/rendered/collector.yaml` via
  `make generate-examples`.
- Documented the operator's controller-runtime metrics (reconcile counts/
  errors/latency, work queue depth/latency, webhook request/latency) in a new
  README appendix, including what a reconciliation and a work queue are