### PR TITLE
[CONTINT-5558] Add pipeline for scraping cAdvisor metrics

### DIFF
--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -137,7 +137,7 @@ config:
                 action: drop
               # Ignore the non-container metrics (from the cgroup or sandbox)
               - source_labels: [container]
-                regex: ""
+                regex: ^(POD)?$
                 action: drop
 
   processors:

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -101,7 +101,7 @@ config:
               - role: node
                 selectors:
                   - role: node
-                    field: metadata.name=${K8S_NODE_NAME}
+                    field: metadata.name=${env:K8S_NODE_NAME}
             relabel_configs:
               - action: replace
                 replacement: kubelet

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -28,7 +28,7 @@ clusterRole:
   create: true
   rules:
     - apiGroups: [""]
-      resources: ["pods", "namespaces", "nodes", "nodes/stats"]
+      resources: ["pods", "namespaces", "nodes", "nodes/stats", "nodes/metrics"]
       verbs: ["get", "watch", "list"]
     - apiGroups: ["apps"]
       resources: ["replicasets"]
@@ -81,12 +81,107 @@ config:
         - container
         - volume
 
+    # cAdvisor metrics from the kubelet
+    prometheus:
+      config:
+        scrape_configs:
+          - job_name: kubelet-cadvisor
+            scheme: https
+            metrics_path: /metrics/cadvisor
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            honor_labels: true
+            honor_timestamps: true
+            authorization:
+              type: Bearer
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            tls_config:
+              insecure_skip_verify: true
+            kubernetes_sd_configs:
+              - role: node
+                selectors:
+                  - role: node
+                    field: metadata.name=${K8S_NODE_NAME}
+            relabel_configs:
+              - action: replace
+                replacement: kubelet
+                target_label: job
+              - action: replace
+                source_labels: [__meta_kubernetes_node_name]
+                target_label: node
+            metric_relabel_configs:
+              # Drop the highest-cardinality / lowest-value cAdvisor series.
+              # Adapted from https://github.com/open-telemetry/opentelemetry-helm-charts/blob/116378e5b1985029de91d9aea2d1cce319f4e016/charts/opentelemetry-kube-stack/templates/_config.tpl#L826-L847
+              - source_labels: [__name__]
+                regex: container_cpu_(load_average_10s)
+                action: drop
+              - source_labels: [__name__]
+                regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                action: drop
+              - source_labels: [__name__]
+                regex: container_memory_(mapped_file|swap)
+                action: drop
+              - source_labels: [__name__]
+                regex: container_(file_descriptors|tasks_state|threads_max)
+                action: drop
+              - source_labels: [__name__]
+                regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+                action: drop
+              - source_labels: [__name__]
+                regex: container_network_.*
+                action: drop
+              # Drop series where the cgroup id is set but the pod label is empty
+              # (non-pod cgroups like system.slice and the kubelet's own resources).
+              - source_labels: [id, pod]
+                regex: .+;
+                action: drop
+              # Ignore the non-container metrics (from the cgroup or sandbox)
+              - source_labels: [container]
+                regex: ""
+                action: drop
+
   processors:
     cumulativetodelta: {}
     deltatorate:
       metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+
+    deltatorate/cadvisor:
+      metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+
+    transform/cadvisor_labels:
+      metric_statements:
+        - context: datapoint
+          statements:
+            - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+            - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+            - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"] != nil
+            - set(attributes["container.id"], attributes["name"]) where attributes["container"] != nil
+            - set(attributes["container.image.name"], attributes["image"]) where attributes["container"] != nil
+            - delete_key(attributes, "pod")
+            - delete_key(attributes, "namespace")
+            - delete_key(attributes, "container")
+            - delete_key(attributes, "name")
+            - delete_key(attributes, "image")
+            - delete_key(attributes, "id")
+
+    # Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/821a9d9c2c1623c4a0ceba5d47b57c48879c3f84/processor/groupbyattrsprocessor
+    # Prometheus metrics are flat, so we need to extract the resource from the datapoint labels
+    groupbyattrs:
+      keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
 
     k8s_attributes:
       auth_type: "serviceAccount"
@@ -199,4 +294,17 @@ config:
         receivers: [datadog/connector, otlp]
         processors:
           [resourcedetection, k8s_attributes, cumulativetodelta, deltatorate]
+        exporters: [datadog/exporter]
+
+      metrics/cadvisor:
+        receivers: [prometheus]
+        processors:
+          [
+            resourcedetection,
+            transform/cadvisor_labels,
+            groupbyattrs,
+            k8s_attributes,
+            cumulativetodelta,
+            deltatorate/cadvisor,
+          ]
         exporters: [datadog/exporter]

--- a/guides/kubernetes/configuration/daemonset-collector.yaml
+++ b/guides/kubernetes/configuration/daemonset-collector.yaml
@@ -173,6 +173,13 @@ config:
             - delete_key(attributes, "name")
             - delete_key(attributes, "image")
             - delete_key(attributes, "id")
+        # Prometheus receiver sets these on the resource from the scrape job/instance;
+        # k8s_attributes cannot overwrite them, so drop them to let the workload's
+        # resource.opentelemetry.io/service.* annotations win.
+        - context: resource
+          statements:
+            - delete_key(attributes, "service.name")
+            - delete_key(attributes, "service.instance.id")
 
     # Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/821a9d9c2c1623c4a0ceba5d47b57c48879c3f84/processor/groupbyattrsprocessor
     # Prometheus metrics are flat, so we need to extract the resource from the datapoint labels

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/Makefile
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/Makefile
@@ -11,7 +11,7 @@ generate-examples:
 	EXAMPLES=$$(find $${EXAMPLES_DIR} -maxdepth 1 -mindepth 1 -type d -exec basename \{\} \;); \
 	for example in $${EXAMPLES}; do \
 		echo "Generating example: $${example}"; \
-		VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name *values.yaml); \
+		VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name '*values.yaml'); \
 		rm -rf "$${EXAMPLES_DIR}/$${example}/rendered"; \
 		for value in $${VALUES}; do \
 			helm template opentelemetry-kube-stack \

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
@@ -17,6 +17,18 @@ spec:
     connectors:
       count/k8s_entities:
         datapoints:
+          k8s.cronjob.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_cronjob_info"
+          k8s.daemonset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_daemonset_created"
           k8s.deployment.count:
             attributes:
             - default_value: unspecified_namespace
@@ -24,6 +36,9 @@ spec:
             conditions:
             - metric.name == "kube_deployment_created"
           k8s.job.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
             conditions:
             - metric.name == "kube_job_owner"
           k8s.namespace.count:
@@ -46,6 +61,12 @@ spec:
               key: type
             conditions:
             - metric.name == "kube_service_spec_type"
+          k8s.statefulset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_statefulset_created"
     exporters:
       datadog/exporter:
         api:
@@ -67,11 +88,6 @@ spec:
         lease_namespace: opentelemetry-operator-system
     processors:
       cumulativetodelta: {}
-      filter/ksm:
-        metrics:
-          metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
       groupbyattrs:
         keys:
         - k8s.pod.uid
@@ -156,6 +172,8 @@ spec:
           - delete_key(attributes, "job_name")
           - set(attributes["kube_service"], attributes["service"])
           - delete_key(attributes, "service")
+          - set(attributes["kube_cronjob"], attributes["cronjob"])
+          - delete_key(attributes, "cronjob")
       transform/rename_uid:
         metric_statements:
         - context: datapoint
@@ -174,6 +192,9 @@ spec:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
     receivers:
       k8s_cluster:
         allocatable_types_to_report:
@@ -327,7 +348,7 @@ spec:
           - job_name: kube-state-metrics
             metric_relabel_configs:
             - action: keep
-              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              regex: kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
               source_labels:
               - __name__
             metrics_path: /metrics
@@ -366,7 +387,6 @@ spec:
           exporters:
           - datadog/exporter
           processors:
-          - filter/ksm
           - transform/ksm_to_dd
           - transform/rename_uid
           - groupbyattrs
@@ -501,6 +521,22 @@ spec:
         metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+      deltatorate/cadvisor:
+        metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+      groupbyattrs:
+        keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
       k8s_attributes:
         extract:
           labels:
@@ -573,6 +609,26 @@ spec:
         - aks
         - k8s_api
         override: false
+      transform/cadvisor_labels:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"]
+            != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"]
+            != nil
+          - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"]
+            != nil
+          - set(attributes["container.id"], attributes["name"]) where attributes["container"]
+            != nil
+          - set(attributes["container.image.name"], attributes["image"]) where attributes["container"]
+            != nil
+          - delete_key(attributes, "pod")
+          - delete_key(attributes, "namespace")
+          - delete_key(attributes, "container")
+          - delete_key(attributes, "name")
+          - delete_key(attributes, "image")
+          - delete_key(attributes, "id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
@@ -699,6 +755,68 @@ spec:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      prometheus/cadvisor:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet-cadvisor
+            kubernetes_sd_configs:
+            - role: node
+              selectors:
+              - field: metadata.name=${env:K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_network_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              source_labels:
+              - id
+              - pod
+            - action: drop
+              regex: ^(POD)?$
+              source_labels:
+              - container
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -728,6 +846,19 @@ spec:
           - otlp
           - host_metrics
           - kubelet_stats
+        metrics/cadvisor:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - transform/cadvisor_labels
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate/cadvisor
+          receivers:
+          - prometheus/cadvisor
         traces:
           exporters:
           - datadog/connector

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
@@ -629,6 +629,10 @@ spec:
           - delete_key(attributes, "name")
           - delete_key(attributes, "image")
           - delete_key(attributes, "id")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ rules:
   resources:
   - namespaces
   - nodes
-  - nodes/proxy
+  - nodes/pods
   - nodes/metrics
   - nodes/stats
   - services

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -516,6 +516,22 @@ spec:
         metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+      deltatorate/cadvisor:
+        metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+      groupbyattrs:
+        keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
       k8s_attributes:
         extract:
           labels:
@@ -583,6 +599,26 @@ spec:
         detectors:
         - k8s_api
         override: false
+      transform/cadvisor_labels:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"]
+            != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"]
+            != nil
+          - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"]
+            != nil
+          - set(attributes["container.id"], attributes["name"]) where attributes["container"]
+            != nil
+          - set(attributes["container.image.name"], attributes["image"]) where attributes["container"]
+            != nil
+          - delete_key(attributes, "pod")
+          - delete_key(attributes, "namespace")
+          - delete_key(attributes, "container")
+          - delete_key(attributes, "name")
+          - delete_key(attributes, "image")
+          - delete_key(attributes, "id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
@@ -709,6 +745,68 @@ spec:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      prometheus/cadvisor:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet-cadvisor
+            kubernetes_sd_configs:
+            - role: node
+              selectors:
+              - field: metadata.name=${env:K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_network_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              source_labels:
+              - id
+              - pod
+            - action: drop
+              regex: ^(POD)?$
+              source_labels:
+              - container
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -738,6 +836,19 @@ spec:
           - otlp
           - host_metrics
           - kubelet_stats
+        metrics/cadvisor:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - transform/cadvisor_labels
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate/cadvisor
+          receivers:
+          - prometheus/cadvisor
         traces:
           exporters:
           - datadog/connector

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -619,6 +619,10 @@ spec:
           - delete_key(attributes, "name")
           - delete_key(attributes, "image")
           - delete_key(attributes, "id")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -165,7 +165,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - nodes/proxy
+      - nodes/pods
     verbs:
       - get
   - apiGroups:

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
@@ -631,6 +631,10 @@ spec:
           - delete_key(attributes, "name")
           - delete_key(attributes, "image")
           - delete_key(attributes, "id")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
@@ -17,6 +17,18 @@ spec:
     connectors:
       count/k8s_entities:
         datapoints:
+          k8s.cronjob.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_cronjob_info"
+          k8s.daemonset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_daemonset_created"
           k8s.deployment.count:
             attributes:
             - default_value: unspecified_namespace
@@ -24,6 +36,9 @@ spec:
             conditions:
             - metric.name == "kube_deployment_created"
           k8s.job.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
             conditions:
             - metric.name == "kube_job_owner"
           k8s.namespace.count:
@@ -46,6 +61,12 @@ spec:
               key: type
             conditions:
             - metric.name == "kube_service_spec_type"
+          k8s.statefulset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_statefulset_created"
     exporters:
       datadog/exporter:
         api:
@@ -67,11 +88,6 @@ spec:
         lease_namespace: opentelemetry-operator-system
     processors:
       cumulativetodelta: {}
-      filter/ksm:
-        metrics:
-          metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
       groupbyattrs:
         keys:
         - k8s.pod.uid
@@ -157,6 +173,8 @@ spec:
           - delete_key(attributes, "job_name")
           - set(attributes["kube_service"], attributes["service"])
           - delete_key(attributes, "service")
+          - set(attributes["kube_cronjob"], attributes["cronjob"])
+          - delete_key(attributes, "cronjob")
       transform/rename_uid:
         metric_statements:
         - context: datapoint
@@ -175,6 +193,9 @@ spec:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
     receivers:
       k8s_cluster:
         allocatable_types_to_report:
@@ -328,7 +349,7 @@ spec:
           - job_name: kube-state-metrics
             metric_relabel_configs:
             - action: keep
-              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              regex: kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
               source_labels:
               - __name__
             metrics_path: /metrics
@@ -367,7 +388,6 @@ spec:
           exporters:
           - datadog/exporter
           processors:
-          - filter/ksm
           - transform/ksm_to_dd
           - transform/rename_uid
           - groupbyattrs
@@ -502,6 +522,22 @@ spec:
         metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+      deltatorate/cadvisor:
+        metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+      groupbyattrs:
+        keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
       k8s_attributes:
         extract:
           labels:
@@ -575,6 +611,26 @@ spec:
               enabled: true
         override: false
         timeout: 15s
+      transform/cadvisor_labels:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"]
+            != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"]
+            != nil
+          - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"]
+            != nil
+          - set(attributes["container.id"], attributes["name"]) where attributes["container"]
+            != nil
+          - set(attributes["container.image.name"], attributes["image"]) where attributes["container"]
+            != nil
+          - delete_key(attributes, "pod")
+          - delete_key(attributes, "namespace")
+          - delete_key(attributes, "container")
+          - delete_key(attributes, "name")
+          - delete_key(attributes, "image")
+          - delete_key(attributes, "id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
@@ -701,6 +757,68 @@ spec:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      prometheus/cadvisor:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet-cadvisor
+            kubernetes_sd_configs:
+            - role: node
+              selectors:
+              - field: metadata.name=${env:K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_network_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              source_labels:
+              - id
+              - pod
+            - action: drop
+              regex: ^(POD)?$
+              source_labels:
+              - container
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -730,6 +848,19 @@ spec:
           - otlp
           - host_metrics
           - kubelet_stats
+        metrics/cadvisor:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - transform/cadvisor_labels
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate/cadvisor
+          receivers:
+          - prometheus/cadvisor
         traces:
           exporters:
           - datadog/connector

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
@@ -17,6 +17,18 @@ spec:
     connectors:
       count/k8s_entities:
         datapoints:
+          k8s.cronjob.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_cronjob_info"
+          k8s.daemonset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_daemonset_created"
           k8s.deployment.count:
             attributes:
             - default_value: unspecified_namespace
@@ -24,6 +36,9 @@ spec:
             conditions:
             - metric.name == "kube_deployment_created"
           k8s.job.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
             conditions:
             - metric.name == "kube_job_owner"
           k8s.namespace.count:
@@ -46,6 +61,12 @@ spec:
               key: type
             conditions:
             - metric.name == "kube_service_spec_type"
+          k8s.statefulset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_statefulset_created"
     exporters:
       datadog/exporter:
         api:
@@ -67,11 +88,6 @@ spec:
         lease_namespace: opentelemetry-operator-system
     processors:
       cumulativetodelta: {}
-      filter/ksm:
-        metrics:
-          metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
       groupbyattrs:
         keys:
         - k8s.pod.uid
@@ -156,6 +172,8 @@ spec:
           - delete_key(attributes, "job_name")
           - set(attributes["kube_service"], attributes["service"])
           - delete_key(attributes, "service")
+          - set(attributes["kube_cronjob"], attributes["cronjob"])
+          - delete_key(attributes, "cronjob")
       transform/rename_uid:
         metric_statements:
         - context: datapoint
@@ -174,6 +192,9 @@ spec:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
     receivers:
       k8s_cluster:
         allocatable_types_to_report:
@@ -327,7 +348,7 @@ spec:
           - job_name: kube-state-metrics
             metric_relabel_configs:
             - action: keep
-              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              regex: kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
               source_labels:
               - __name__
             metrics_path: /metrics
@@ -366,7 +387,6 @@ spec:
           exporters:
           - datadog/exporter
           processors:
-          - filter/ksm
           - transform/ksm_to_dd
           - transform/rename_uid
           - groupbyattrs
@@ -501,6 +521,22 @@ spec:
         metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+      deltatorate/cadvisor:
+        metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+      groupbyattrs:
+        keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
       k8s_attributes:
         extract:
           labels:
@@ -573,6 +609,26 @@ spec:
             k8s.cluster.name:
               enabled: true
         override: false
+      transform/cadvisor_labels:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"]
+            != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"]
+            != nil
+          - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"]
+            != nil
+          - set(attributes["container.id"], attributes["name"]) where attributes["container"]
+            != nil
+          - set(attributes["container.image.name"], attributes["image"]) where attributes["container"]
+            != nil
+          - delete_key(attributes, "pod")
+          - delete_key(attributes, "namespace")
+          - delete_key(attributes, "container")
+          - delete_key(attributes, "name")
+          - delete_key(attributes, "image")
+          - delete_key(attributes, "id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
@@ -699,6 +755,68 @@ spec:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      prometheus/cadvisor:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet-cadvisor
+            kubernetes_sd_configs:
+            - role: node
+              selectors:
+              - field: metadata.name=${env:K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_network_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              source_labels:
+              - id
+              - pod
+            - action: drop
+              regex: ^(POD)?$
+              source_labels:
+              - container
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -728,6 +846,19 @@ spec:
           - otlp
           - host_metrics
           - kubelet_stats
+        metrics/cadvisor:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - transform/cadvisor_labels
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate/cadvisor
+          receivers:
+          - prometheus/cadvisor
         traces:
           exporters:
           - datadog/connector

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
@@ -629,6 +629,10 @@ spec:
           - delete_key(attributes, "name")
           - delete_key(attributes, "image")
           - delete_key(attributes, "id")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
@@ -17,6 +17,18 @@ spec:
     connectors:
       count/k8s_entities:
         datapoints:
+          k8s.cronjob.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_cronjob_info"
+          k8s.daemonset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_daemonset_created"
           k8s.deployment.count:
             attributes:
             - default_value: unspecified_namespace
@@ -24,6 +36,9 @@ spec:
             conditions:
             - metric.name == "kube_deployment_created"
           k8s.job.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
             conditions:
             - metric.name == "kube_job_owner"
           k8s.namespace.count:
@@ -46,6 +61,12 @@ spec:
               key: type
             conditions:
             - metric.name == "kube_service_spec_type"
+          k8s.statefulset.count:
+            attributes:
+            - default_value: unspecified_namespace
+              key: namespace
+            conditions:
+            - metric.name == "kube_statefulset_created"
     exporters:
       datadog/exporter:
         api:
@@ -67,11 +88,6 @@ spec:
         lease_namespace: opentelemetry-operator-system
     processors:
       cumulativetodelta: {}
-      filter/ksm:
-        metrics:
-          metric:
-          - metric.name == "kube_service_spec_type"
-          - metric.name == "kube_namespace_created"
       groupbyattrs:
         keys:
         - k8s.pod.uid
@@ -151,6 +167,8 @@ spec:
           - delete_key(attributes, "job_name")
           - set(attributes["kube_service"], attributes["service"])
           - delete_key(attributes, "service")
+          - set(attributes["kube_cronjob"], attributes["cronjob"])
+          - delete_key(attributes, "cronjob")
       transform/rename_uid:
         metric_statements:
         - context: datapoint
@@ -169,6 +187,9 @@ spec:
         - convert_sum_to_gauge() where metric.name == "k8s.deployment.count"
         - convert_sum_to_gauge() where metric.name == "k8s.pod.count"
         - convert_sum_to_gauge() where metric.name == "k8s.namespace.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.statefulset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.daemonset.count"
+        - convert_sum_to_gauge() where metric.name == "k8s.cronjob.count"
     receivers:
       k8s_cluster:
         allocatable_types_to_report:
@@ -322,7 +343,7 @@ spec:
           - job_name: kube-state-metrics
             metric_relabel_configs:
             - action: keep
-              regex: kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
+              regex: kube_cronjob_.*|kube_daemonset_.*|kube_deployment_.*|kube_job_.*|kube_namespace_created|kube_node_.*|kube_pod_.*|kube_replicaset_.*|kube_statefulset_.*|kube_service_spec_type
               source_labels:
               - __name__
             metrics_path: /metrics
@@ -361,7 +382,6 @@ spec:
           exporters:
           - datadog/exporter
           processors:
-          - filter/ksm
           - transform/ksm_to_dd
           - transform/rename_uid
           - groupbyattrs
@@ -496,6 +516,22 @@ spec:
         metrics:
         - k8s.pod.network.io
         - k8s.pod.network.errors
+      deltatorate/cadvisor:
+        metrics:
+        - container_cpu_usage_seconds_total
+        - container_cpu_cfs_periods_total
+        - container_cpu_cfs_throttled_periods_total
+        - container_cpu_cfs_throttled_seconds_total
+        - container_cpu_system_seconds_total
+        - container_cpu_user_seconds_total
+        - container_fs_reads_bytes_total
+        - container_fs_writes_bytes_total
+      groupbyattrs:
+        keys:
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.container.name
+        - container.id
       k8s_attributes:
         extract:
           labels:
@@ -563,6 +599,26 @@ spec:
         detectors:
         - k8s_api
         override: false
+      transform/cadvisor_labels:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"]
+            != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"]
+            != nil
+          - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"]
+            != nil
+          - set(attributes["container.id"], attributes["name"]) where attributes["container"]
+            != nil
+          - set(attributes["container.image.name"], attributes["image"]) where attributes["container"]
+            != nil
+          - delete_key(attributes, "pod")
+          - delete_key(attributes, "namespace")
+          - delete_key(attributes, "container")
+          - delete_key(attributes, "name")
+          - delete_key(attributes, "image")
+          - delete_key(attributes, "id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
@@ -689,6 +745,68 @@ spec:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      prometheus/cadvisor:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet-cadvisor
+            kubernetes_sd_configs:
+            - role: node
+              selectors:
+              - field: metadata.name=${env:K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_network_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              source_labels:
+              - id
+              - pod
+            - action: drop
+              regex: ^(POD)?$
+              source_labels:
+              - container
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              insecure_skip_verify: true
     service:
       extensions:
       - health_check
@@ -718,6 +836,19 @@ spec:
           - otlp
           - host_metrics
           - kubelet_stats
+        metrics/cadvisor:
+          exporters:
+          - datadog/exporter
+          processors:
+          - resource_detection/env
+          - transform/insert_k8s_cluster_name
+          - transform/cadvisor_labels
+          - groupbyattrs
+          - k8s_attributes
+          - cumulativetodelta
+          - deltatorate/cadvisor
+          receivers:
+          - prometheus/cadvisor
         traces:
           exporters:
           - datadog/connector

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
@@ -619,6 +619,10 @@ spec:
           - delete_key(attributes, "name")
           - delete_key(attributes, "image")
           - delete_key(attributes, "id")
+        - context: resource
+          statements:
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "service.instance.id")
       transform/insert_k8s_cluster_name:
         log_statements:
         - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -334,11 +334,106 @@ collectors:
           enabled: false
 
     config:
+      receivers:
+        # cAdvisor metrics from the kubelet.
+        prometheus/cadvisor:
+          config:
+            scrape_configs:
+              - job_name: kubelet-cadvisor
+                scheme: https
+                metrics_path: /metrics/cadvisor
+                scrape_interval: 15s
+                scrape_timeout: 10s
+                honor_labels: true
+                honor_timestamps: true
+                authorization:
+                  type: Bearer
+                  credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tls_config:
+                  insecure_skip_verify: true
+                kubernetes_sd_configs:
+                  - role: node
+                    selectors:
+                      - role: node
+                        field: metadata.name=${env:K8S_NODE_NAME}
+                relabel_configs:
+                  - action: replace
+                    replacement: kubelet
+                    target_label: job
+                  - action: replace
+                    source_labels: [__meta_kubernetes_node_name]
+                    target_label: node
+                metric_relabel_configs:
+                  # Drop the highest-cardinality / lowest-value cAdvisor series.
+                  - source_labels: [__name__]
+                    regex: container_cpu_(load_average_10s)
+                    action: drop
+                  - source_labels: [__name__]
+                    regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                    action: drop
+                  - source_labels: [__name__]
+                    regex: container_memory_(mapped_file|swap)
+                    action: drop
+                  - source_labels: [__name__]
+                    regex: container_(file_descriptors|tasks_state|threads_max)
+                    action: drop
+                  - source_labels: [__name__]
+                    regex: container_spec_(cpu_period|cpu_quota|cpu_shares|memory_reservation_limit_bytes|memory_swap_limit_bytes)
+                    action: drop
+                  - source_labels: [__name__]
+                    regex: container_network_.*
+                    action: drop
+                  # Drop series where the cgroup id is set but the pod label is empty
+                  # (non-pod cgroups like system.slice and the kubelet's own resources).
+                  - source_labels: [id, pod]
+                    regex: .+;
+                    action: drop
+                  # Ignore the non-container metrics (from the cgroup or sandbox)
+                  - source_labels: [container]
+                    regex: ^(POD)?$
+                    action: drop
+
       processors:
         deltatorate:
           metrics:
             - k8s.pod.network.io
             - k8s.pod.network.errors
+
+        deltatorate/cadvisor:
+          metrics:
+            - container_cpu_usage_seconds_total
+            - container_cpu_cfs_periods_total
+            - container_cpu_cfs_throttled_periods_total
+            - container_cpu_cfs_throttled_seconds_total
+            - container_cpu_system_seconds_total
+            - container_cpu_user_seconds_total
+            - container_fs_reads_bytes_total
+            - container_fs_writes_bytes_total
+
+        transform/cadvisor_labels:
+          metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+                - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+                - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"] != nil
+                - set(attributes["container.id"], attributes["name"]) where attributes["container"] != nil
+                - set(attributes["container.image.name"], attributes["image"]) where attributes["container"] != nil
+                - delete_key(attributes, "pod")
+                - delete_key(attributes, "namespace")
+                - delete_key(attributes, "container")
+                - delete_key(attributes, "name")
+                - delete_key(attributes, "image")
+                - delete_key(attributes, "id")
+
+        # Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/821a9d9c2c1623c4a0ceba5d47b57c48879c3f84/processor/groupbyattrsprocessor
+        # Prometheus metrics are flat, so we need to extract the resource from the datapoint labels
+        groupbyattrs:
+          keys:
+            - k8s.pod.name
+            - k8s.namespace.name
+            - k8s.container.name
+            - container.id
 
       connectors:
         datadog/connector: {}
@@ -371,6 +466,20 @@ collectors:
               - transform/insert_k8s_cluster_name
               - cumulativetodelta
               - deltatorate
+            exporters: [datadog/exporter]
+
+          metrics/cadvisor:
+            receivers: [prometheus/cadvisor]
+            processors:
+              [
+                resource_detection/env,
+                transform/insert_k8s_cluster_name,
+                transform/cadvisor_labels,
+                groupbyattrs,
+                k8s_attributes,
+                cumulativetodelta,
+                deltatorate/cadvisor,
+              ]
             exporters: [datadog/exporter]
 instrumentation:
   enabled: true

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -425,6 +425,13 @@ collectors:
                 - delete_key(attributes, "name")
                 - delete_key(attributes, "image")
                 - delete_key(attributes, "id")
+            # Prometheus receiver sets these on the resource from the scrape job/instance;
+            # k8s_attributes cannot overwrite them, so drop them to let the workload's
+            # resource.opentelemetry.io/service.* annotations win.
+            - context: resource
+              statements:
+                - delete_key(attributes, "service.name")
+                - delete_key(attributes, "service.instance.id")
 
         # Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/821a9d9c2c1623c4a0ceba5d47b57c48879c3f84/processor/groupbyattrsprocessor
         # Prometheus metrics are flat, so we need to extract the resource from the datapoint labels


### PR DESCRIPTION
### What does this PR do?
This recommends a change to the daemonset collector for customers that is essentially a separate pipeline for scraping the Prometheus metric output of cAdvisor (bottom pipeline). The config is largely adapted from the [opentelemetry-kube-stack](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/116378e5b1985029de91d9aea2d1cce319f4e016/charts/opentelemetry-kube-stack/templates/_config.tpl#L826-L847) and modified to fit existing Datadog conventions. 
 
<img width="1297" height="487" alt="image" src="https://github.com/user-attachments/assets/bce65ef1-d217-4181-ab29-534706e6fdd4" />

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5558