### PR TITLE
feat: Inject POC-ready Datadog .NET instrumentation in place of OTel .NET Auto-Instrumentation

### DIFF
--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -56,5 +60,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -55,5 +59,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -56,5 +60,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/export-to-datadog-and-jaeger/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/export-to-datadog-and-jaeger/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -55,5 +59,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -56,5 +60,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/instrumentation.yaml
@@ -25,6 +25,10 @@ spec:
   env:
     - name: DD_AGENT_HOST
       value: "ddagent-kube-stack-datadog.opentelemetry-operator-system.svc.cluster.local"
+    - name: DD_DBM_PROPAGATION_MODE
+      value: "full"
+    - name: DD_DBM_TRACE_PREPARED_STATEMENTS
+      value: "true"
     - name: DD_ENV
       value: ""
     - name: DD_LOGS_OTEL_ENABLED
@@ -56,5 +60,12 @@ spec:
     image: ghcr.io/cyrille-leclerc/dd-autoinstrumentation-python:4.11.1
     volumeLimitSize: 500Mi
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    env:
+    - name: CORECLR_PROFILER
+      value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+    - name: CORECLR_PROFILER_PATH
+      value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+    - name: DD_DOTNET_TRACER_HOME
+      value: /otel-auto-instrumentation-dotnet
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
 

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -427,7 +427,20 @@ instrumentation:
   # Operator from falling back to its default agent image and yielding invalid init containers.
   # TODO: File an issue against the opentelemetry-kube-stack Helm chart for this behavior.
   dotnet:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
+    image: ghcr.io/zacharycmontoya/dd-autoinstrumentation-dotnet:3.52.0
+    # Unlike the other languages, .NET needs more setup to instrument an application:
+    # - The CORECLR_PROFILER_PATH env variable must be set (matching other languages)
+    # - The .NET Tracer's DD_DOTNET_TRACER_HOME env variable must be set
+    # - The CORECLR_PROFILER env variable must the CLSID of the CLR profiler that is initialized,
+    # and currently the opentelemetry-operator sets it to OpenTelemetry's CLSID {918728DD-259F-4A6A-AC2B-B85E1B658318},
+    # whereas the Datadog's CLSID is {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    env:
+      - name: CORECLR_PROFILER
+        value: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+      - name: CORECLR_PROFILER_PATH
+        value: /otel-auto-instrumentation-dotnet/linux/Datadog.Tracer.Native.so
+      - name: DD_DOTNET_TRACER_HOME
+        value: /otel-auto-instrumentation-dotnet
   java:
     # image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.28.1
     image: registry.ddbuild.io/ssi/dd-otel-autoinstrumentation-java:glci133182091 # 1.66.0-SNAPSHOT~3ee7b79b7a


### PR DESCRIPTION
### What does this PR do?

Injects dd-trace-dotnet instead of otel-dotnet-instrumentation when using the provided `values.yaml` deployment.

Confirmed locally that this reports traces and logs (didn't check metrics). Notes:
- The image is not a stable production-ready build
- The current solution requires setting environment variables in the values.yaml deployment file. This can be limited (or outright eliminated) with changes to dd-trace-dotnet

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
