### PR TITLE
[opentelemetry-kube-stack] Use chart's top-level resourceAttributes for k8s.cluster.name and deployment.environment.name

### DIFF
--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/Makefile
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/Makefile
@@ -17,7 +17,7 @@ generate-examples:
 			helm template opentelemetry-kube-stack \
 				open-telemetry/opentelemetry-kube-stack  \
 				--namespace opentelemetry-operator-system \
-				--version "0.20.2" \
+				--version "0.20.8" \
 				--values ./values.yaml --values $${value} \
 				--output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
 			mv $${EXAMPLES_DIR}/$${example}/rendered/opentelemetry-kube-stack/templates/* "$${EXAMPLES_DIR}/$${example}/rendered"; \

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/README.md
@@ -98,7 +98,7 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm repo update
 helm upgrade --install opentelemetry-kube-stack \
   open-telemetry/opentelemetry-kube-stack \
-  --version 0.20.2 \
+  --version 0.20.8 \
   --namespace opentelemetry-operator-system \
   --values ./values.yaml \
   --values ./deployment/values.yaml
@@ -109,9 +109,8 @@ helm upgrade --install opentelemetry-kube-stack \
 For EKS, AKS, and GKE, the installer enables the corresponding resource-detection preset in both collectors. The
 OpenTelemetry Collector then automatically populates `k8s.cluster.name`.
 
-For other Kubernetes platforms, the installer passes the supplied cluster name through `clusterName` and
-`defaultCRConfig.env[2].value`. The `transform/insert_k8s_cluster_name` processor adds it only when the resource does
-not already have a `k8s.cluster.name` attribute.
+ For other Kubernetes platforms, the
+installer sets `resourceAttributes.k8s.cluster.name` to the supplied cluster name.
 
 See `examples/` for rendered values and manifests for each deployment type.
 
@@ -123,7 +122,7 @@ Both collectors default to `500m` CPU / `1Gi` memory limits and `200m` CPU / `50
 
 Verified against:
 
-- `opentelemetry-kube-stack` chart `>= 0.20.2`
+- `opentelemetry-kube-stack` chart `>= 0.20.8`
 - Collector image `otel/opentelemetry-collector-contrib >= 0.154.0` (pinned in values.yaml under `opentelemetry-operator.manager.collectorImage`)
 
 [chart]: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/clusterrole.yaml
@@ -187,4 +187,3 @@ subjects:
   # quirk of the Operator
   name: "opentelemetry-kube-stack-daemon-collector"
   namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-kube-stack-cluster
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -130,6 +130,11 @@ spec:
         - sources:
           - from: resource_attribute
             name: k8s.pod.uid
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource_detection/env:
         aks:
           resource_attributes:
@@ -139,19 +144,6 @@ spec:
         - aks
         - k8s_api
         override: false
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
       transform/ksm_to_dd:
         metric_statements:
         - context: datapoint
@@ -380,7 +372,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - k8s_objects
         metrics:
@@ -392,9 +384,9 @@ spec:
           - groupbyattrs
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - transform/sum_to_gauge
+          - resource/global
           receivers:
           - otlp
           - prometheus/ksm
@@ -403,6 +395,8 @@ spec:
         metrics/count:
           exporters:
           - count/k8s_entities
+          processors:
+          - resource/global
           receivers:
           - prometheus/ksm
         metrics/otel_operator:
@@ -410,8 +404,8 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
+          - resource/global
           receivers:
           - prometheus/otel_operator
       telemetry:
@@ -466,8 +460,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -487,7 +479,7 @@ metadata:
   name: opentelemetry-kube-stack-daemon
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -595,6 +587,11 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource/hostname:
         attributes:
         - action: insert
@@ -633,19 +630,6 @@ spec:
           statements:
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "service.instance.id")
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     receivers:
       file_log:
         exclude: []
@@ -832,7 +816,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
           - file_log
@@ -842,9 +826,9 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - deltatorate
+          - resource/global
           receivers:
           - datadog/connector
           - otlp
@@ -855,12 +839,12 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - transform/cadvisor_labels
           - groupbyattrs
           - k8s_attributes
           - cumulativetodelta
           - deltatorate/cadvisor
+          - resource/global
           receivers:
           - prometheus/cadvisor
         traces:
@@ -869,12 +853,14 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
         traces/sampling:
           exporters:
           - datadog/exporter
+          processors:
+          - resource/global
           receivers:
           - datadog/connector
       telemetry:
@@ -939,8 +925,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -962,4 +946,3 @@ spec:
   - name: hostfs
     hostPath:
       path: /
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/hooks.yaml
@@ -61,5 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"
-
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: opentelemetry-kube-stack
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"    
@@ -41,4 +41,3 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/deployment.yaml
@@ -86,4 +86,3 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/role.yaml
@@ -154,5 +154,3 @@ rules:
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/service.yaml
@@ -27,4 +27,3 @@ spec:
   selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: opentelemetry-kube-stack
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/kube-state-metrics/servicemonitor.yaml
@@ -23,4 +23,3 @@ spec:
   endpoints:
     - port: http
       honorLabels: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -190,4 +190,3 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -4,5 +4,3 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/certmanager.yaml
@@ -41,4 +41,3 @@ metadata:
   namespace: opentelemetry-operator-system
 spec:
   selfSigned: {}
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/clusterrole.yaml
@@ -416,5 +416,3 @@ rules:
       - /metrics
     verbs:
       - get
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -20,5 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/deployment.yaml
@@ -102,4 +102,3 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/role.yaml
@@ -197,4 +197,3 @@ rules:
       - patch
       - update
       - watch
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/rolebinding.yaml
@@ -21,4 +21,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/service.yaml
@@ -45,4 +45,3 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: opentelemetry-kube-stack
     app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -57,4 +57,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -116,4 +116,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/aks-deployment/values.yaml
@@ -1,10 +1,7 @@
-clusterName: ""
+resourceAttributes:
+  deployment.environment.name: "production"
 defaultCRConfig:
   presets:
     resourceDetection:
       aks:
         enabled: true
-instrumentation:
-  resource:
-    resourceAttributes:
-      deployment.environment.name: "production"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
@@ -187,4 +187,3 @@ subjects:
   # quirk of the Operator
   name: "opentelemetry-kube-stack-daemon-collector"
   namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-kube-stack-cluster
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -130,23 +130,15 @@ spec:
         - sources:
           - from: resource_attribute
             name: k8s.pod.uid
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource_detection/env:
         detectors:
         - k8s_api
         override: false
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
       transform/ksm_to_dd:
         metric_statements:
         - context: datapoint
@@ -375,7 +367,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - k8s_objects
         metrics:
@@ -387,9 +379,9 @@ spec:
           - groupbyattrs
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - transform/sum_to_gauge
+          - resource/global
           receivers:
           - otlp
           - prometheus/ksm
@@ -398,6 +390,8 @@ spec:
         metrics/count:
           exporters:
           - count/k8s_entities
+          processors:
+          - resource/global
           receivers:
           - prometheus/ksm
         metrics/otel_operator:
@@ -405,8 +399,8 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
+          - resource/global
           receivers:
           - prometheus/otel_operator
       telemetry:
@@ -461,8 +455,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -482,7 +474,7 @@ metadata:
   name: opentelemetry-kube-stack-daemon
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -590,6 +582,11 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource/hostname:
         attributes:
         - action: insert
@@ -623,19 +620,6 @@ spec:
           statements:
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "service.instance.id")
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     receivers:
       file_log:
         exclude: []
@@ -822,7 +806,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
           - file_log
@@ -832,9 +816,9 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - deltatorate
+          - resource/global
           receivers:
           - datadog/connector
           - otlp
@@ -845,12 +829,12 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - transform/cadvisor_labels
           - groupbyattrs
           - k8s_attributes
           - cumulativetodelta
           - deltatorate/cadvisor
+          - resource/global
           receivers:
           - prometheus/cadvisor
         traces:
@@ -859,12 +843,14 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
         traces/sampling:
           exporters:
           - datadog/exporter
+          processors:
+          - resource/global
           receivers:
           - datadog/connector
       telemetry:
@@ -929,8 +915,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -952,4 +936,3 @@ spec:
   - name: hostfs
     hostPath:
       path: /
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,5 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"
-
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: opentelemetry-kube-stack
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"    
@@ -41,4 +41,3 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/deployment.yaml
@@ -86,4 +86,3 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/role.yaml
@@ -154,5 +154,3 @@ rules:
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/service.yaml
@@ -27,4 +27,3 @@ spec:
   selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: opentelemetry-kube-stack
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/kube-state-metrics/servicemonitor.yaml
@@ -23,4 +23,3 @@ spec:
   endpoints:
     - port: http
       honorLabels: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -190,4 +190,3 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -4,5 +4,3 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
@@ -41,4 +41,3 @@ metadata:
   namespace: opentelemetry-operator-system
 spec:
   selfSigned: {}
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -416,5 +416,3 @@ rules:
       - /metrics
     verbs:
       - get
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -20,5 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
@@ -102,4 +102,3 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
@@ -197,4 +197,3 @@ rules:
       - patch
       - update
       - watch
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
@@ -21,4 +21,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
@@ -45,4 +45,3 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: opentelemetry-kube-stack
     app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -57,4 +57,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -116,4 +116,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/clusterrole.yaml
@@ -187,4 +187,3 @@ subjects:
   # quirk of the Operator
   name: "opentelemetry-kube-stack-daemon-collector"
   namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-kube-stack-cluster
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -130,6 +130,11 @@ spec:
         - sources:
           - from: resource_attribute
             name: k8s.pod.uid
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource_detection/env:
         detectors:
         - eks
@@ -140,19 +145,6 @@ spec:
               enabled: true
         override: false
         timeout: 15s
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
       transform/ksm_to_dd:
         metric_statements:
         - context: datapoint
@@ -381,7 +373,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - k8s_objects
         metrics:
@@ -393,9 +385,9 @@ spec:
           - groupbyattrs
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - transform/sum_to_gauge
+          - resource/global
           receivers:
           - otlp
           - prometheus/ksm
@@ -404,6 +396,8 @@ spec:
         metrics/count:
           exporters:
           - count/k8s_entities
+          processors:
+          - resource/global
           receivers:
           - prometheus/ksm
         metrics/otel_operator:
@@ -411,8 +405,8 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
+          - resource/global
           receivers:
           - prometheus/otel_operator
       telemetry:
@@ -467,8 +461,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -488,7 +480,7 @@ metadata:
   name: opentelemetry-kube-stack-daemon
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -596,6 +588,11 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource/hostname:
         attributes:
         - action: insert
@@ -635,19 +632,6 @@ spec:
           statements:
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "service.instance.id")
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     receivers:
       file_log:
         exclude: []
@@ -834,7 +818,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
           - file_log
@@ -844,9 +828,9 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - deltatorate
+          - resource/global
           receivers:
           - datadog/connector
           - otlp
@@ -857,12 +841,12 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - transform/cadvisor_labels
           - groupbyattrs
           - k8s_attributes
           - cumulativetodelta
           - deltatorate/cadvisor
+          - resource/global
           receivers:
           - prometheus/cadvisor
         traces:
@@ -871,12 +855,14 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
         traces/sampling:
           exporters:
           - datadog/exporter
+          processors:
+          - resource/global
           receivers:
           - datadog/connector
       telemetry:
@@ -941,8 +927,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -964,4 +948,3 @@ spec:
   - name: hostfs
     hostPath:
       path: /
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/hooks.yaml
@@ -61,5 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"
-
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: opentelemetry-kube-stack
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"    
@@ -41,4 +41,3 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/deployment.yaml
@@ -86,4 +86,3 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/role.yaml
@@ -154,5 +154,3 @@ rules:
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/service.yaml
@@ -27,4 +27,3 @@ spec:
   selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: opentelemetry-kube-stack
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/kube-state-metrics/servicemonitor.yaml
@@ -23,4 +23,3 @@ spec:
   endpoints:
     - port: http
       honorLabels: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -190,4 +190,3 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -4,5 +4,3 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/certmanager.yaml
@@ -41,4 +41,3 @@ metadata:
   namespace: opentelemetry-operator-system
 spec:
   selfSigned: {}
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/clusterrole.yaml
@@ -416,5 +416,3 @@ rules:
       - /metrics
     verbs:
       - get
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -20,5 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/deployment.yaml
@@ -102,4 +102,3 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/role.yaml
@@ -197,4 +197,3 @@ rules:
       - patch
       - update
       - watch
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/rolebinding.yaml
@@ -21,4 +21,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/service.yaml
@@ -45,4 +45,3 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: opentelemetry-kube-stack
     app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -57,4 +57,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -116,4 +116,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/eks-deployment/values.yaml
@@ -1,10 +1,7 @@
-clusterName: ""
+resourceAttributes:
+  deployment.environment.name: "production"
 defaultCRConfig:
   presets:
     resourceDetection:
       eks:
         enabled: true
-instrumentation:
-  resource:
-    resourceAttributes:
-      deployment.environment.name: "production"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/clusterrole.yaml
@@ -187,4 +187,3 @@ subjects:
   # quirk of the Operator
   name: "opentelemetry-kube-stack-daemon-collector"
   namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-kube-stack-cluster
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -130,6 +130,11 @@ spec:
         - sources:
           - from: resource_attribute
             name: k8s.pod.uid
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource_detection/env:
         detectors:
         - gcp
@@ -139,19 +144,6 @@ spec:
             k8s.cluster.name:
               enabled: true
         override: false
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
       transform/ksm_to_dd:
         metric_statements:
         - context: datapoint
@@ -380,7 +372,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - k8s_objects
         metrics:
@@ -392,9 +384,9 @@ spec:
           - groupbyattrs
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - transform/sum_to_gauge
+          - resource/global
           receivers:
           - otlp
           - prometheus/ksm
@@ -403,6 +395,8 @@ spec:
         metrics/count:
           exporters:
           - count/k8s_entities
+          processors:
+          - resource/global
           receivers:
           - prometheus/ksm
         metrics/otel_operator:
@@ -410,8 +404,8 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
+          - resource/global
           receivers:
           - prometheus/otel_operator
       telemetry:
@@ -466,8 +460,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -487,7 +479,7 @@ metadata:
   name: opentelemetry-kube-stack-daemon
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -595,6 +587,11 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
       resource/hostname:
         attributes:
         - action: insert
@@ -633,19 +630,6 @@ spec:
           statements:
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "service.instance.id")
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     receivers:
       file_log:
         exclude: []
@@ -832,7 +816,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
           - file_log
@@ -842,9 +826,9 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - deltatorate
+          - resource/global
           receivers:
           - datadog/connector
           - otlp
@@ -855,12 +839,12 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - transform/cadvisor_labels
           - groupbyattrs
           - k8s_attributes
           - cumulativetodelta
           - deltatorate/cadvisor
+          - resource/global
           receivers:
           - prometheus/cadvisor
         traces:
@@ -869,12 +853,14 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
         traces/sampling:
           exporters:
           - datadog/exporter
+          processors:
+          - resource/global
           receivers:
           - datadog/connector
       telemetry:
@@ -939,8 +925,6 @@ spec:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: ""
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -962,4 +946,3 @@ spec:
   - name: hostfs
     hostPath:
       path: /
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/hooks.yaml
@@ -61,5 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"
-
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: opentelemetry-kube-stack
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"    
@@ -41,4 +41,3 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/deployment.yaml
@@ -86,4 +86,3 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/role.yaml
@@ -154,5 +154,3 @@ rules:
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/service.yaml
@@ -27,4 +27,3 @@ spec:
   selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: opentelemetry-kube-stack
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/kube-state-metrics/servicemonitor.yaml
@@ -23,4 +23,3 @@ spec:
   endpoints:
     - port: http
       honorLabels: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -190,4 +190,3 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -4,5 +4,3 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/certmanager.yaml
@@ -41,4 +41,3 @@ metadata:
   namespace: opentelemetry-operator-system
 spec:
   selfSigned: {}
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/clusterrole.yaml
@@ -416,5 +416,3 @@ rules:
       - /metrics
     verbs:
       - get
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -20,5 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/deployment.yaml
@@ -102,4 +102,3 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/role.yaml
@@ -197,4 +197,3 @@ rules:
       - patch
       - update
       - watch
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/rolebinding.yaml
@@ -21,4 +21,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/service.yaml
@@ -45,4 +45,3 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: opentelemetry-kube-stack
     app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -57,4 +57,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -116,4 +116,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/gcp-deployment/values.yaml
@@ -1,10 +1,7 @@
-clusterName: ""
+resourceAttributes:
+  deployment.environment.name: "production"
 defaultCRConfig:
   presets:
     resourceDetection:
       gcp:
         enabled: true
-instrumentation:
-  resource:
-    resourceAttributes:
-      deployment.environment.name: "production"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/clusterrole.yaml
@@ -187,4 +187,3 @@ subjects:
   # quirk of the Operator
   name: "opentelemetry-kube-stack-daemon-collector"
   namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-kube-stack-cluster
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -130,23 +130,18 @@ spec:
         - sources:
           - from: resource_attribute
             name: k8s.pod.uid
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
+        - action: upsert
+          key: k8s.cluster.name
+          value: my_k8s_cluster
       resource_detection/env:
         detectors:
         - k8s_api
         override: false
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
       transform/ksm_to_dd:
         metric_statements:
         - context: datapoint
@@ -375,7 +370,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - k8s_objects
         metrics:
@@ -387,9 +382,9 @@ spec:
           - groupbyattrs
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - transform/sum_to_gauge
+          - resource/global
           receivers:
           - otlp
           - prometheus/ksm
@@ -398,6 +393,8 @@ spec:
         metrics/count:
           exporters:
           - count/k8s_entities
+          processors:
+          - resource/global
           receivers:
           - prometheus/ksm
         metrics/otel_operator:
@@ -405,8 +402,8 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
+          - resource/global
           receivers:
           - prometheus/otel_operator
       telemetry:
@@ -459,10 +456,8 @@ spec:
         apiVersion: v1
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
-    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=my_k8s_cluster"
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: "my_k8s_cluster"
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -482,7 +477,7 @@ metadata:
   name: opentelemetry-kube-stack-daemon
   namespace: opentelemetry-operator-system
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"        
@@ -590,6 +585,14 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
+        - action: upsert
+          key: k8s.cluster.name
+          value: my_k8s_cluster
       resource/hostname:
         attributes:
         - action: insert
@@ -623,19 +626,6 @@ spec:
           statements:
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "service.instance.id")
-      transform/insert_k8s_cluster_name:
-        log_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        metric_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-        - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}")
-          where (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"]
-          == "") and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     receivers:
       file_log:
         exclude: []
@@ -822,7 +812,7 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
           - file_log
@@ -832,9 +822,9 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - cumulativetodelta
           - deltatorate
+          - resource/global
           receivers:
           - datadog/connector
           - otlp
@@ -845,12 +835,12 @@ spec:
           - datadog/exporter
           processors:
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
           - transform/cadvisor_labels
           - groupbyattrs
           - k8s_attributes
           - cumulativetodelta
           - deltatorate/cadvisor
+          - resource/global
           receivers:
           - prometheus/cadvisor
         traces:
@@ -859,12 +849,14 @@ spec:
           processors:
           - k8s_attributes
           - resource_detection/env
-          - transform/insert_k8s_cluster_name
+          - resource/global
           receivers:
           - otlp
         traces/sampling:
           exporters:
           - datadog/exporter
+          processors:
+          - resource/global
           receivers:
           - datadog/connector
       telemetry:
@@ -927,10 +919,8 @@ spec:
         apiVersion: v1
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
-    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=my_k8s_cluster"
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
   
-  - name: OTEL_K8S_CLUSTER_NAME
-    value: "my_k8s_cluster"
   - name: DD_API_KEY
     valueFrom:
       secretKeyRef:
@@ -952,4 +942,3 @@ spec:
   - name: hostfs
     hostPath:
       path: /
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/hooks.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/hooks.yaml
@@ -61,5 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"
-
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/instrumentation.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: opentelemetry-kube-stack
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.2
+    helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "opentelemetry-kube-stack"    
@@ -33,6 +33,7 @@ spec:
     addK8sUIDAttributes: true
     resourceAttributes:
       deployment.environment.name: production
+      k8s.cluster.name: my_k8s_cluster
   java:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.28.1
   nodejs:
@@ -41,4 +42,3 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/deployment.yaml
@@ -86,4 +86,3 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/role.yaml
@@ -154,5 +154,3 @@ rules:
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/service.yaml
@@ -27,4 +27,3 @@ spec:
   selector:    
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: opentelemetry-kube-stack
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/servicemonitor.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/kube-state-metrics/servicemonitor.yaml
@@ -23,4 +23,3 @@ spec:
   endpoints:
     - port: http
       honorLabels: true
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -190,4 +190,3 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -4,5 +4,3 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/certmanager.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/certmanager.yaml
@@ -41,4 +41,3 @@ metadata:
   namespace: opentelemetry-operator-system
 spec:
   selfSigned: {}
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/clusterrole.yaml
@@ -416,5 +416,3 @@ rules:
       - /metrics
     verbs:
       - get
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -20,5 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/deployment.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/deployment.yaml
@@ -102,4 +102,3 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/role.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/role.yaml
@@ -197,4 +197,3 @@ rules:
       - patch
       - update
       - watch
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/rolebinding.yaml
@@ -21,4 +21,3 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: opentelemetry-operator-system
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/service.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/service.yaml
@@ -45,4 +45,3 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: opentelemetry-kube-stack
     app.kubernetes.io/component: controller-manager
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -57,4 +57,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -116,4 +116,3 @@ spec:
     runAsGroup: 65532
     runAsNonRoot: true
     runAsUser: 65532
-

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/examples/manually-set-k8s-cluster-name/values.yaml
@@ -1,20 +1,3 @@
-clusterName: "my_k8s_cluster"
-defaultCRConfig:
-  env:
-    - name: DD_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: datadog-secret
-          key: api-key
-    - name: DD_SITE
-      valueFrom:
-        secretKeyRef:
-          name: datadog-secret
-          key: dd-site
-          optional: true
-    - name: OTEL_K8S_CLUSTER_NAME
-      value: "my_k8s_cluster"
-instrumentation:
-  resource:
-    resourceAttributes:
-      deployment.environment.name: "production"
+resourceAttributes:
+  k8s.cluster.name: "my_k8s_cluster"
+  deployment.environment.name: "production"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/install
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/install
@@ -103,15 +103,21 @@ echo "Installing OpenTelemetry Kube Stack Helm Chart..."
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm repo update
 
+HELM_SET_ARGS=(
+    --set-string "resourceAttributes.deployment\.environment\.name=$DEPLOYMENT_ENVIRONMENT_NAME"
+    --set defaultCRConfig.presets.resourceDetection.aks.enabled=$RESOURCE_DETECTION_AKS_ENABLED
+    --set defaultCRConfig.presets.resourceDetection.eks.enabled=$RESOURCE_DETECTION_EKS_ENABLED
+    --set defaultCRConfig.presets.resourceDetection.gcp.enabled=$RESOURCE_DETECTION_GCP_ENABLED
+)
+
+if [[ -n "$K8S_CLUSTER_NAME" ]]; then
+    HELM_SET_ARGS+=(--set-string "resourceAttributes.k8s\.cluster\.name=$K8S_CLUSTER_NAME")
+fi
+
 helm upgrade opentelemetry-kube-stack \
     open-telemetry/opentelemetry-kube-stack \
-    --version 0.20.2 \
+    --version 0.20.8 \
     --install \
     --namespace opentelemetry-operator-system \
-    --set-string clusterName=$K8S_CLUSTER_NAME \
-    --set-string defaultCRConfig.env[2].value=$K8S_CLUSTER_NAME \
-    --set defaultCRConfig.presets.resourceDetection.aks.enabled=$RESOURCE_DETECTION_AKS_ENABLED \
-    --set defaultCRConfig.presets.resourceDetection.eks.enabled=$RESOURCE_DETECTION_EKS_ENABLED \
-    --set defaultCRConfig.presets.resourceDetection.gcp.enabled=$RESOURCE_DETECTION_GCP_ENABLED \
-    --set-string instrumentation.resource.resourceAttributes.deployment\\.environment\\.name="$DEPLOYMENT_ENVIRONMENT_NAME" \
+    "${HELM_SET_ARGS[@]}" \
     -f "$SCRIPT_DIR/values.yaml"

--- a/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
+++ b/guides/kubernetes/configuration/opentelemetry-kube-stack/values.yaml
@@ -1,4 +1,8 @@
 clusterName: ""
+
+resourceAttributes:
+  deployment.environment.name: production # overwrite as needed
+
 opentelemetry-operator:
   manager:
     collectorImage:
@@ -27,8 +31,6 @@ defaultCRConfig:
           name: datadog-secret
           key: dd-site
           optional: true
-    - name: OTEL_K8S_CLUSTER_NAME
-      value: ""
 
   # Starting-point resource allocation. Scale up for large clusters.
   resources:
@@ -62,25 +64,6 @@ defaultCRConfig:
       cumulativetodelta: {}
       resource_detection/env:
         override: false
-      transform/insert_k8s_cluster_name:
-        # waiting for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49970
-        # that will let us leverage the `k8s.cluster.name` defined as a collector env variable,
-        # use a dedicated processor to insert `k8s.cluster.name` in the resource attributes if not already set by the resource detection processor.
-        metric_statements:
-          - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}") 
-            where 
-              (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == "")
-              and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        log_statements:
-          - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}") 
-            where 
-              (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == "")
-              and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
-        trace_statements:
-          - set(resource.attributes["k8s.cluster.name"], "${env:OTEL_K8S_CLUSTER_NAME}") 
-            where 
-              (resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == "")
-              and "${env:OTEL_K8S_CLUSTER_NAME}" != ""
     exporters:
       datadog/exporter:
         api:
@@ -276,14 +259,13 @@ collectors:
         pipelines:
           logs:
             receivers: [k8s_objects]
-            processors: [resource_detection/env, transform/insert_k8s_cluster_name]
+            processors: [resource_detection/env]
             exporters: [datadog/exporter]
 
           metrics/otel_operator:
             receivers: [prometheus/otel_operator]
             processors:
               - resource_detection/env
-              - transform/insert_k8s_cluster_name
               - cumulativetodelta
             exporters: [datadog/exporter]
 
@@ -299,7 +281,6 @@ collectors:
               - groupbyattrs
               - k8s_attributes
               - resource_detection/env
-              - transform/insert_k8s_cluster_name
               - cumulativetodelta
               - transform/sum_to_gauge
             exporters: [datadog/exporter]
@@ -453,12 +434,12 @@ collectors:
         pipelines:
           logs:
             receivers: [otlp]
-            processors: [resource_detection/env, transform/insert_k8s_cluster_name]
+            processors: [resource_detection/env]
             exporters: [datadog/exporter]
 
           traces:
             receivers: [otlp]
-            processors: [resource_detection/env, transform/insert_k8s_cluster_name]
+            processors: [resource_detection/env]
             exporters: [datadog/connector]
 
           # Add sampling processors here if needed.
@@ -470,7 +451,6 @@ collectors:
             receivers: [datadog/connector, otlp]
             processors:
               - resource_detection/env
-              - transform/insert_k8s_cluster_name
               - cumulativetodelta
               - deltatorate
             exporters: [datadog/exporter]
@@ -480,7 +460,6 @@ collectors:
             processors:
               [
                 resource_detection/env,
-                transform/insert_k8s_cluster_name,
                 transform/cadvisor_labels,
                 groupbyattrs,
                 k8s_attributes,
@@ -502,9 +481,6 @@ instrumentation:
     # Daemon collector Service DNS. Update the collector name and namespace
     # to match your install: http://<release>-daemon-collector.<namespace>.svc.cluster.local:4318
     endpoint: http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
-  resource:
-    resourceAttributes:
-      deployment.environment.name: production # overwrite as needed
   sampler:
     type: parentbased_always_on
   # The opentelemetry-kube-stack Helm chart renders language sections even when empty, preventing the


### PR DESCRIPTION
### What does this PR do?

Upstream chart PR [open-telemetry/opentelemetry-helm-charts#2393](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2393) adds a top-level `resourceAttributes` map that renders as a `resource/global` upsert processor on every collector pipeline and is merged into the Instrumentation CR's `resource.resourceAttributes`. 

This lets us delete our homegrown workaround for [contrib#49970](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49970) and unify how `k8s.cluster.name` and `deployment.environment.name` get set.



